### PR TITLE
Comments: Phase 6 — polish, privacy copy, expanded Playwright suite, CI Vitest job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Run Playwright Tests
+name: Run Tests
 
 on:
   push:
@@ -7,17 +7,56 @@ on:
   pull_request:
 
 jobs:
-  test:
+  test-unit:
     runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set Up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20.9.0
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run Vitest (unit + integration)
+        run: npm run test:unit
+        env:
+          # Load-bearing test values. Integration tests override these in
+          # `beforeEach`; these workflow-level values only need to satisfy the
+          # minimum-length guards in lib/auth.ts, lib/deleteToken.ts, lib/ipHash.ts
+          # and pages/api/auth/login.ts so module import does not throw.
+          # Deliberately NOT secrets: test-only, ephemeral CI, never touches real data.
+          IP_HASH_SALT: "ci-test-salt-aaaaaaaaaaaaaaaaaaaa"
+          DELETE_TOKEN_SECRET: "ci-test-secret-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          IRON_SESSION_PASSWORD: "ci-test-session-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          OWNER_PASSWORD: "ci-test-owner-password-aaaaaaaaaaaaaaaaaa"
+          # Non-load-bearing: integration tests mock the Upstash and Resend SDKs
+          # directly (see tests/integration/comments-api-phase5.test.js).
+          UPSTASH_REDIS_REST_URL: "https://ci-placeholder.upstash.io"
+          UPSTASH_REDIS_REST_TOKEN: "ci-placeholder-token"
+          RESEND_API_KEY: "re_ci_placeholder"
+          OWNER_NOTIFY_EMAIL: "test@example.com"
+          OWNER_FROM_EMAIL: "test@example.com"
+          NEXT_PUBLIC_SITE_URL: "http://localhost:3000"
+
+  test:
+    runs-on: ubuntu-22.04
+    needs: test-unit
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set Up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.9.0
+          cache: npm
 
       - name: Update apt and Install Missing Dependencies
         run: |
@@ -25,7 +64,7 @@ jobs:
           sudo apt-get install -y libicu-dev libasound2 libffi-dev libx264-dev
 
       - name: Install Dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install sharp
         run: npm install --cpu=wasm32 sharp
@@ -38,20 +77,6 @@ jobs:
 
       - name: Install Playwright browsers
         run: npx playwright install
-
-      - name: Run NextJS application
-        run: npm run start &
-
-      - name: Wait for NextJS app to start
-        run: |
-          timeout=0
-          until [[ $timeout -eq 30 ]]; do
-            if nc -z localhost 3000; then
-              break
-            fi
-            timeout=$((timeout + 1))
-            sleep 1
-          done
 
       - name: Run Playwright Tests
         run: npx playwright test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,11 @@ jobs:
       - name: Set Up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.9.0
+          # Vitest 4.x bundles rolldown, which imports `styleText` from
+          # `node:util`. That helper is only exported as stable in Node 22+
+          # (it landed experimental in 20.12 and was gated behind an export
+          # flag before that). Pin to the current active 22 LTS line.
+          node-version: 22.11.0
           cache: npm
 
       - name: Install Dependencies
@@ -55,7 +59,11 @@ jobs:
       - name: Set Up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.9.0
+          # Vitest 4.x bundles rolldown, which imports `styleText` from
+          # `node:util`. That helper is only exported as stable in Node 22+
+          # (it landed experimental in 20.12 and was gated behind an export
+          # flag before that). Pin to the current active 22 LTS line.
+          node-version: 22.11.0
           cache: npm
 
       - name: Update apt and Install Missing Dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,11 +17,16 @@ jobs:
       - name: Set Up Node.js
         uses: actions/setup-node@v4
         with:
-          # Vitest 4.x bundles rolldown, which imports `styleText` from
-          # `node:util`. That helper is only exported as stable in Node 22+
-          # (it landed experimental in 20.12 and was gated behind an export
-          # flag before that). Pin to the current active 22 LTS line.
-          node-version: 22.11.0
+          # Vitest 4.x bundles rolldown, which:
+          #   1. Imports `styleText` from `node:util` — stable from Node 22.
+          #   2. Ships platform-specific native bindings (e.g.
+          #      `@rolldown/binding-linux-x64-gnu`) with
+          #      `engines: { node: "^20.19.0 || >=22.12.0" }`. Pinning below
+          #      that floor causes `npm ci` to skip the optional dep and
+          #      the test process throws `Cannot find native binding`.
+          # `22.12.0` is the minimum that satisfies both — bump freely to
+          # any newer 22.x LTS patch.
+          node-version: 22.12.0
           cache: npm
 
       - name: Install Dependencies
@@ -59,11 +64,16 @@ jobs:
       - name: Set Up Node.js
         uses: actions/setup-node@v4
         with:
-          # Vitest 4.x bundles rolldown, which imports `styleText` from
-          # `node:util`. That helper is only exported as stable in Node 22+
-          # (it landed experimental in 20.12 and was gated behind an export
-          # flag before that). Pin to the current active 22 LTS line.
-          node-version: 22.11.0
+          # Vitest 4.x bundles rolldown, which:
+          #   1. Imports `styleText` from `node:util` — stable from Node 22.
+          #   2. Ships platform-specific native bindings (e.g.
+          #      `@rolldown/binding-linux-x64-gnu`) with
+          #      `engines: { node: "^20.19.0 || >=22.12.0" }`. Pinning below
+          #      that floor causes `npm ci` to skip the optional dep and
+          #      the test process throws `Cannot find native binding`.
+          # `22.12.0` is the minimum that satisfies both — bump freely to
+          # any newer 22.x LTS patch.
+          node-version: 22.12.0
           cache: npm
 
       - name: Update apt and Install Missing Dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,3 +98,33 @@ jobs:
 
       - name: Run Playwright Tests
         run: npx playwright test
+        env:
+          # Log-noise guard: the Playwright `webServer` runs
+          # `npm run start` without DATABASE_URL. Tests that care about the
+          # comment list stub `/api/comments` via `page.route()`, but
+          # unrelated specs (blog / theme) merely navigate to post pages
+          # and the eagerly-firing CommentsSection fetch would otherwise
+          # log a `DatabaseConfigError` stack trace on every page load.
+          # The API handler checks this flag and short-circuits to an
+          # empty list. Production builds do not set this.
+          PLAYWRIGHT_TEST_COMMENT_STUB: "1"
+          # Activates the Playwright seam in pages/owner/comments/delete.js
+          # so CMT-E2E-22..26 can assert token-state UI without a real
+          # Neon row. Same non-prod guard pattern.
+          PLAYWRIGHT_TEST_COMMENT_PREVIEW: "1"
+          # Test-only values — these only need to satisfy min-length
+          # guards so modules don't throw on import / first use. Same
+          # values as the test-unit job for consistency; never touch real
+          # data. `DELETE_TOKEN_SECRET` is additionally read by the
+          # `signToken()` helper in tests/comments.spec.js for
+          # CMT-E2E-23 / -25.
+          DELETE_TOKEN_SECRET: "ci-test-secret-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          IP_HASH_SALT: "ci-test-salt-aaaaaaaaaaaaaaaaaaaa"
+          IRON_SESSION_PASSWORD: "ci-test-session-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          OWNER_PASSWORD: "ci-test-owner-password-aaaaaaaaaaaaaaaaaa"
+          UPSTASH_REDIS_REST_URL: "https://ci-placeholder.upstash.io"
+          UPSTASH_REDIS_REST_TOKEN: "ci-placeholder-token"
+          RESEND_API_KEY: "re_ci_placeholder"
+          OWNER_NOTIFY_EMAIL: "test@example.com"
+          OWNER_FROM_EMAIL: "test@example.com"
+          NEXT_PUBLIC_SITE_URL: "http://localhost:3000"

--- a/components/comments/CommentForm.js
+++ b/components/comments/CommentForm.js
@@ -30,7 +30,7 @@
  *   - Fires track("comment_submitted") from @vercel/analytics on success.
  */
 import { useEffect, useRef, useState } from "react";
-import { track } from "@vercel/analytics";
+import { trackEvent } from "../../lib/analytics";
 import { submitComment, CommentApiError } from "../../lib/comments";
 
 const MAX_BODY = 1000;
@@ -160,7 +160,7 @@ export default function CommentForm({ postId, onSuccess }) {
       });
 
       setFormState("success");
-      track("comment_submitted");
+      trackEvent("comment_submitted");
       onSuccess(newComment);
 
       // Reset form after 3 s

--- a/components/comments/CommentForm.js
+++ b/components/comments/CommentForm.js
@@ -226,9 +226,9 @@ export default function CommentForm({ postId, onSuccess }) {
   return (
     <div data-testid="comment-form">
       {/* Privacy notice — one sentence, above the form */}
-      <p className="font-bold text-sm text-gray-600 dark:text-slate-400 mb-3">
-        Comments are public. Your name will be shown; don&apos;t include
-        personal info you wouldn&apos;t put online.
+      <p className="text-sm text-gray-600 dark:text-slate-400 mb-3">
+        Comments are public and permanent. Your display name will be visible
+        to all readers. No email address or IP address is stored.
       </p>
 
       {/* Top-of-form server / profanity / links / rate-limit error */}

--- a/components/comments/CommentItem.js
+++ b/components/comments/CommentItem.js
@@ -16,7 +16,7 @@
  *     Using CSS `hidden` would leave DOM nodes that could be targeted by
  *     automated attacks; conditional rendering eliminates the surface.
  */
-import { useRef, useState, useEffect } from "react";
+import { useCallback, useRef, useState, useEffect } from "react";
 import Date from "../date";
 
 export default function CommentItem({ comment, isOwner, onDelete }) {
@@ -25,8 +25,27 @@ export default function CommentItem({ comment, isOwner, onDelete }) {
   // Refs for focus management during inline confirm flow
   const deleteButtonRef = useRef(null);
   const cancelButtonRef = useRef(null);
+  // Only restore focus to the delete button after the user cancels — NOT
+  // after `setConfirming(false)` caused by a successful delete (that path
+  // unmounts this item entirely).
+  const shouldFocusDelete = useRef(false);
 
-  // Move focus to Cancel button when confirm row opens
+  // Ref callback for the delete button: fires synchronously when React
+  // attaches / detaches the DOM node. This is more reliable than a post-
+  // commit `useEffect` because it guarantees we focus the button at the
+  // exact moment it remounts — no race with the browser moving focus to
+  // <body> after the Cancel button unmounts.
+  const setDeleteButtonRef = useCallback((node) => {
+    deleteButtonRef.current = node;
+    if (node && shouldFocusDelete.current) {
+      node.focus();
+      shouldFocusDelete.current = false;
+    }
+  }, []);
+
+  // Move focus to Cancel button when the confirm row opens. (The opposite
+  // direction — Cancel → delete — is handled by setDeleteButtonRef above
+  // because the delete button is conditionally rendered.)
   useEffect(() => {
     if (confirming && cancelButtonRef.current) {
       cancelButtonRef.current.focus();
@@ -38,11 +57,9 @@ export default function CommentItem({ comment, isOwner, onDelete }) {
   }
 
   function handleCancel() {
+    // The ref callback on the re-mounting delete button will focus it.
+    shouldFocusDelete.current = true;
     setConfirming(false);
-    // Return focus to the original delete trigger
-    if (deleteButtonRef.current) {
-      deleteButtonRef.current.focus();
-    }
   }
 
   function handleConfirm() {
@@ -71,7 +88,7 @@ export default function CommentItem({ comment, isOwner, onDelete }) {
         {/* Delete affordance — ONLY rendered when isOwner === true */}
         {isOwner && !confirming && (
           <button
-            ref={deleteButtonRef}
+            ref={setDeleteButtonRef}
             type="button"
             onClick={handleDeleteClick}
             aria-label={`Delete comment by ${comment.author}`}

--- a/components/comments/CommentList.js
+++ b/components/comments/CommentList.js
@@ -20,7 +20,7 @@
  *   - Fires `track("comment_load_more")` from @vercel/analytics on each click.
  */
 import { useRef, useState, useEffect } from "react";
-import { track } from "@vercel/analytics";
+import { trackEvent } from "../../lib/analytics";
 import CommentItem from "./CommentItem";
 
 const INITIAL_COUNT = 5;
@@ -51,7 +51,7 @@ export default function CommentList({ comments, isOwner, onDelete }) {
   }, [visibleCount]);
 
   function handleShowMore() {
-    track("comment_load_more");
+    trackEvent("comment_load_more");
     setVisibleCount((c) => c + INCREMENT);
   }
 

--- a/components/comments/CommentsSection.js
+++ b/components/comments/CommentsSection.js
@@ -56,6 +56,7 @@ class CommentErrorBoundary extends Component {
       return (
         <p
           role="alert"
+          data-testid="comments-error"
           className="text-red-600 dark:text-red-400 text-base py-4"
         >
           Comments could not be loaded. Refresh the page to try again.

--- a/components/comments/CommentsSection.js
+++ b/components/comments/CommentsSection.js
@@ -26,7 +26,7 @@
  *   - track("comment_submitted") is fired inside CommentForm.
  */
 import { Component, useEffect, useRef, useState } from "react";
-import { track } from "@vercel/analytics";
+import { trackEvent } from "../../lib/analytics";
 import { fetchComments, deleteComment } from "../../lib/comments";
 import CommentSkeleton from "./CommentSkeleton";
 import CommentList from "./CommentList";
@@ -112,6 +112,13 @@ function CommentsSectionInner({ postId, isOwner }) {
   }, [comments]);
 
   function handleSuccess(newComment) {
+    // Honeypot sentinel: the server returns a fake comment with this fixed
+    // all-zeros UUID when the bot bait field is populated. We must not render
+    // it — otherwise the bot (or a curious dev tools user) sees their fake
+    // submission appear in the list, defeating the deceptive design that the
+    // server's response shape is meant to support.
+    // Server side: see pages/api/comments/index.ts (honeypot branch).
+    if (!newComment || newComment.id === "00000000-0000-0000-0000-000000000000") return;
     shouldFocusNew.current = true;
     setComments((prev) => [newComment, ...prev]);
     setTotal((t) => t + 1);
@@ -125,7 +132,7 @@ function CommentsSectionInner({ postId, isOwner }) {
       setComments((prev) => prev.filter((c) => c.id !== id));
       setTotal((t) => Math.max(t - 1, 0));
       setDeletedAnnounce(true);
-      track("comment_deleted");
+      trackEvent("comment_deleted");
       // Reset the live region after a moment so repeat deletions re-trigger it
       setTimeout(() => setDeletedAnnounce(false), 1500);
     } catch (err) {

--- a/docs/comments-phase-6-audit-report.md
+++ b/docs/comments-phase-6-audit-report.md
@@ -1,0 +1,125 @@
+# Phase 6 Final Security Audit Report
+
+**Date:** 2026-04-22
+**Auditor:** security-auditor (Claude Agent)
+**Scope:** Comments feature — `lib/comments/`, `lib/ipHash.ts`, `lib/rateLimit.ts`, `lib/auth.ts`, `lib/deleteToken.ts`, `lib/mail.ts`, `pages/api/comments/`, `pages/api/owner/`, `pages/api/auth/`, `pages/owner/comments/`, `components/comments/`
+**Baseline:** Phase 5 audit (0 Critical / 0 High, 2 Medium / 4 Low — all fixed in PR #87)
+
+---
+
+## Summary
+
+- **Total checks run:** 30
+- **Pass:** 30
+- **Fail (blocking):** 0
+- **Fail (non-blocking):** 0
+- **New findings vs Phase 5 baseline:** None. No new Critical, High, Medium, or Low findings.
+
+---
+
+## Findings by Group
+
+### Group 1 — Data Handling
+
+| Check | Result | Notes |
+|---|---|---|
+| D-1 | PASS | `grep remoteAddress\|x-forwarded-for\|extractClientIp lib/comments/ pages/api/comments/` — zero results. Raw IP handling is confined to `lib/ipHash.ts` and `lib/rateLimit.ts` only. |
+| D-2 | PASS | `lib/rateLimit.ts` line 97: `key = hashIp(rawIp)`. `hashIp` call precedes `ratelimiter.limit(key)` at line 123. |
+| D-3 | PASS | `grep -in "ip" lib/comments/db.ts` returns one match on line 12 — the word "slips" in a code comment. Zero column name matches. INSERT at line 101 names only `post_id`, `author`, `body`. |
+| D-4 | PASS | `pages/api/comments/index.ts`: Zod `NewCommentSchema.safeParse(body)` runs at step 3 (line 141). `db.insert({ postId: parsed.data.postId, author: parsed.data.author, body: parsed.data.body })` runs at step 5 (line 166). Zod-validated data only reaches the DB. |
+| D-5 | PASS | `grep -in "email" lib/comments/` returns one match: `db.ts` line 117, a comment about the "email link" (delete notification). No email column exists in the `CommentRow` interface or any INSERT/SELECT. `types.ts` has no email field in `Comment` or `NewCommentInput`. |
+
+### Group 2 — Input Handling
+
+| Check | Result | Notes |
+|---|---|---|
+| I-1 | PASS | `grep -rn "dangerouslySetInnerHTML" components/comments/` returns three results, all in JSDoc comments warning against its use. Zero runtime uses. |
+| I-2 | PASS | `lib/comments/schema.ts` line 26: `.refine((value) => !hasLinks(value), …)` — Zod refinement runs server-side in `pages/api/comments/index.ts` step 3. Link rejection is server-authoritative. |
+| I-3 | PASS | `containsProfanity(parsed.data.body)` called at step 4 (line 153), after `db.insert` at step 5 (line 166). Correct order. |
+| I-4 | PASS | `lib/comments/schema.ts` line 25: `.max(1000)` present. Body length cap is enforced by Zod server-side. |
+| I-5 | PASS | Honeypot check `body.url` is step 2 (line 125); Zod parse is step 3 (line 141). Correct order. |
+| I-6 | PASS | All five DB calls in `lib/comments/db.ts` use the Neon `sql` tagged template literal. Zero string concatenation found. |
+
+### Group 3 — Auth & Session
+
+| Check | Result | Notes |
+|---|---|---|
+| A-1 | PASS | `pages/api/comments/[id].ts` line 60: `if (session.isOwner !== true)` — checked at step 3, before UUID validation. |
+| A-2 | PASS | `verifyOrigin(req)` called at step 4 (line 66) using URL-parsed origin comparison in `lib/auth.ts`. |
+| A-3 | PASS | `verifyCsrf(req, session)` called at step 5 (line 73) using `crypto.timingSafeEqual` in `lib/auth.ts`. |
+| A-4 | PASS | `grep -rn "localStorage" lib/ pages/api/` — zero results. |
+| A-5 | PASS | `lib/auth.ts` `sessionOptions.cookieOptions` (line 87–92): `httpOnly: true`, `secure: isSecureCookieContext()`, `sameSite: "lax"`. All three flags present. |
+| A-6 | PASS | `lib/auth.ts` line 79: `pw.length < MIN_SESSION_PASSWORD_LENGTH` (32) enforced at request time; `pages/api/auth/login.ts` line 128 enforces `MIN_OWNER_PASSWORD_LENGTH = 32` for `OWNER_PASSWORD`. Both enforced in code. |
+| A-7 | PASS | `lib/deleteToken.ts` line 167: `crypto.timingSafeEqual(providedSig, expectedSig)`. Present with correct buffer-length guard at line 166. |
+| A-8 | PASS | `lib/deleteToken.ts` `verifyDeleteToken`: `expectedSig` is computed unconditionally at line 162, before the expiry check at line 175. Bad signature returns before expiry check (line 170), but the signature computation always runs — an expired token with a bad signature correctly returns `BAD_SIGNATURE` not `EXPIRED`. Both checks are performed on every path. |
+
+### Group 4 — Rate Limiting & Spam
+
+| Check | Result | Notes |
+|---|---|---|
+| R-1 | PASS | `checkLimit(req)` is step 1 (line 106) in `handlePost`. First operation before any parsing or DB work. |
+| R-2 | PASS | `lib/rateLimit.ts`: three catch blocks (lines 98–108, 113–119, 133–141) all return `{ allowed: true }`. Intentional fail-open documented in module header. |
+| R-3 | PASS | `pages/api/comments/index.ts` lines 108–110: `res.setHeader("Retry-After", String(limit.retryAfter))` set before the 429 response. |
+| R-4 | PASS | `lib/ipHash.ts` line 48: `const MIN_IP_HASH_SALT_LENGTH = 16`. Enforced at line 61. |
+
+### Group 5 — Email
+
+| Check | Result | Notes |
+|---|---|---|
+| E-1 | PASS | `notifyOwnerOfComment` called at step 6 (line 187) inside a try/catch. The 201 response is sent at step 7 (line 193) unconditionally after email. Email failure cannot fail the POST. |
+| E-2 | PASS | `grep -rn "email" lib/comments/` — one match (a comment in `db.ts`). No stored email field anywhere in the comments data layer. |
+| E-3 | PASS | `lib/mail.ts` line 26: `import { Resend } from "resend"`. Resend SDK used exclusively; no raw SMTP construction. |
+| E-4 | PASS | `checkLimit` is step 1; `notifyOwnerOfComment` is step 6. Rate limit runs before email call. |
+
+### Group 6 — Secrets & Config
+
+| Check | Result | Notes |
+|---|---|---|
+| S-1 | PASS | `.env.example` documents all 11 environment variables from the Phase 6 inventory with placeholder values and sensitivity/scoping guidance. No secrets present. |
+| S-2 | PASS | `git log -p --follow -- .env*` — `.env.local` has never been committed (zero history). `.env.example` contains only placeholder values. No real credentials in git history. |
+| S-3 | PASS | Confirmed by owner via Vercel dashboard (`vercel env ls production`): `DATABASE_URL`, `RESEND_API_KEY`, `OWNER_PASSWORD`, `IRON_SESSION_PASSWORD`, `IP_HASH_SALT`, `DELETE_TOKEN_SECRET`, `UPSTASH_REDIS_REST_TOKEN` all Production-scoped only. |
+| S-4 | PASS | `lib/deleteToken.ts` line 37: `const MIN_SECRET_LENGTH = 32`. Enforced at line 58–62 in `getSecret()`. |
+
+### Group 7 — Analytics PII
+
+| Check | Result | Notes |
+|---|---|---|
+| P-1 | PASS | Three `track()` calls confirmed zero-property: `track("comment_submitted")` (`CommentForm.js:163`), `track("comment_load_more")` (`CommentList.js:54`), `track("comment_deleted")` (`CommentsSection.js:128`). No author, body, email, or IP passed as event properties. `@vercel/analytics` is in `package.json` `dependencies` (not devDependencies). |
+
+---
+
+## Findings Detail
+
+No FAIL items. No findings detail section required.
+
+---
+
+## Regression Check vs Phase 5 Baseline
+
+| Finding | Location | Status |
+|---|---|---|
+| M-02 — Resend error logging PII | `lib/mail.ts` line 153 | STILL CLOSED. Only `statusCode` and `errorName` logged; full error object never written. The outer catch at line 166 restricts to `err.message` only. |
+| L-01 — commentPreview.id leak | `pages/owner/comments/delete.js` line 71 | STILL CLOSED. `commentPreview` object contains only `postId`, `author`, `body`, `createdAt`. The `id` field is explicitly excluded with an inline comment noting the omission. |
+| L-03 — raw DB error logged | `pages/owner/comments/delete.js` line 84 | STILL CLOSED. `err: err instanceof Error ? err.message : "unknown error"` — only `err.message` is serialised. |
+| L-04 — oversized Zod cap | `pages/api/owner/delete-by-token.ts` line 43 | STILL CLOSED. Cap is `max(512)`. Comment documents the realistic token length (~130 chars) and the 4x headroom rationale. |
+| I-04 — IP_HASH_SALT minimum length | `lib/ipHash.ts` line 48 | STILL CLOSED. `MIN_IP_HASH_SALT_LENGTH = 16` declared and enforced. |
+
+All five Phase 5 regressions confirmed closed. No regressions detected.
+
+---
+
+## Additional Observations
+
+These are non-blocking observations that were noticed during evidence gathering. They are not checklist items and require no action before merge.
+
+1. **XFF first-vs-last entry (`lib/ipHash.ts` line 104):** The code reads the left-most (first) `x-forwarded-for` entry, with an explicit deployment-assumption comment noting this is only safe on Vercel, where the platform edge controls XFF. The comment also warns that a topology change (self-hosted Nginx, CDN-in-front-of-Vercel, etc.) would require switching to the right-most entry. The decision is correctly documented and intentional for this deployment context.
+
+2. **`delete.js` `data-testid` attributes are already in place** — `pages/owner/comments/delete.js` lines 182 and 227 carry `data-testid="delete-success"` and `data-testid="confirm-token-delete"` respectively, plus `data-testid="delete-preview"` at line 193. The Phase 6E Playwright test stubs (CMT-E2E-15) are fully supported without any additional markup changes.
+
+3. **`csrf_token` cookie set in `login.ts` is not `HttpOnly`** — this is by design (the double-submit pattern requires JS to read it). The implementation comment correctly explains this. Worth keeping the non-`HttpOnly` status documented explicitly so future readers don't treat it as an oversight.
+
+---
+
+## Overall Verdict
+
+**READY TO SHIP** — all 30 blocking checks passed. No new findings versus the Phase 5 baseline. All five Phase 5 regressions confirmed closed.

--- a/docs/comments-phase-6-plan.md
+++ b/docs/comments-phase-6-plan.md
@@ -1,0 +1,680 @@
+# Comments Feature — Phase 6 Implementation Plan (Polish & Launch)
+
+> **Status:** Planning. Phases 1–5 merged to `main` via PR #87.  
+> **Goal:** Harden, instrument, and verify the comments feature before actively promoting it.
+
+---
+
+## Out of Scope for Phase 6
+
+The following items will not be implemented in Phase 6 and should not be reopened without a new planning session:
+
+- Threaded replies / nested comments
+- Comment editing by the author
+- Upvotes / reactions
+- Markdown or rich-text formatting in comments
+- Commenter email notifications
+- Moderation queue / approval workflow
+- CAPTCHA (honeypot + rate limiting is sufficient at this traffic level)
+- Automated GDPR data-retention pipeline (manual retention is acceptable)
+- Multi-user admin authentication
+- Comment search or filtering
+
+---
+
+## Dependency Graph
+
+The six sub-tasks have the following ordering constraints. Tasks on the same level can be dispatched to implementation agents in parallel.
+
+```
+Wave 1 (parallel, no dependencies on each other)
+  ├── 6A — Privacy notice copy audit
+  ├── 6B — IP hashing verification
+  └── 6F — Final security review (read-only audit — no code changes)
+
+Wave 2 (depends on 6B completing, parallel otherwise)
+  ├── 6C — Error boundary (depends on nothing, but schedule after 6A so
+  │         the boundary wraps the final privacy copy)
+  └── 6D — Analytics events (instruments existing code, no dependencies)
+
+Wave 3 (depends on 6A, 6C, 6D being done so E2E tests the finished state)
+  └── 6E — Playwright E2E expansion
+```
+
+**Critical path:** 6A → (6C, 6D) → 6E.  
+**6B** and **6F** are independently parallelisable and should land before 6E to be covered by tests and the final checklist respectively.
+
+---
+
+## 6A — Privacy Notice Copy Audit
+
+### What Was Shipped
+
+`CommentForm.js` line 229 currently renders:
+
+```
+Comments are public. Your name will be shown; don't include
+personal info you wouldn't put online.
+```
+
+This appears above the form, styled `font-bold text-sm text-gray-600 dark:text-slate-400`.
+
+### Acceptance Criteria
+
+- [ ] The privacy notice is present and visible above the form in the rendered page.
+- [ ] The copy accurately states what is collected (name, comment text) and what is **not** stored (IP address, email).
+- [ ] The notice does not over-promise on retention (no "your comment will be deleted after X days" unless a retention policy exists).
+- [ ] The copy is truthful: IPs are never written to the `comments` table (confirmed in 6B); no email column exists in the schema.
+- [ ] Passes WCAG AA contrast in both light and dark mode (the existing Tailwind classes are already verified; no change needed unless copy wrapping is affected).
+
+### Findings from Code Review
+
+The current schema (`lib/comments/db.ts`) inserts only `post_id`, `author`, and `body`. No email column, no IP column. The rate limiter in `lib/rateLimit.ts` hashes the IP before it touches Upstash Redis and never writes it to Postgres. This means:
+
+- The copy can truthfully state that IP addresses are not stored.
+- The copy should note that comments are permanently public until manually removed.
+
+### Recommended Revised Copy
+
+```
+Comments are public and permanent. Your display name will be visible to
+all readers. No email address or IP address is stored.
+```
+
+This is tighter and removes the somewhat paternalistic "don't include personal info" framing while being factually more precise.
+
+### Files to Change
+
+**`components/comments/CommentForm.js`** — update the `<p>` at line 229:
+
+```diff
+-        <p className="font-bold text-sm text-gray-600 dark:text-slate-400 mb-3">
+-          Comments are public. Your name will be shown; don&apos;t include
+-          personal info you wouldn&apos;t put online.
+-        </p>
++        <p className="text-sm text-gray-600 dark:text-slate-400 mb-3">
++          Comments are public and permanent. Your display name will be visible
++          to all readers. No email address or IP address is stored.
++        </p>
+```
+
+Note: also drop `font-bold` — bold weight on a disclaimer reads as a warning label, which is heavier than needed.
+
+### Risk / Trade-offs
+
+- **Why change at all?** The original copy implies the site collects personal info and asks users to self-censor. The revised copy is simply more accurate.
+- **Why not a full privacy policy page?** This is a personal blog with minimal PII. A linked policy page would be overkill and introduce maintenance burden. The inline sentence is proportionate. Revisit only if the site receives significant international traffic or if the privacy posture changes.
+
+### Dependencies
+
+None. Can land independently.
+
+### Rollout Notes
+
+No env vars needed. No Vercel config changes. Update the privacy copy in `CommentForm.js` and redeploy.
+
+---
+
+## 6B — IP Hashing Verification
+
+### What Was Shipped
+
+Phase 5 introduced `lib/ipHash.ts` (HMAC-SHA256, keyed on `IP_HASH_SALT`) and wired it into `lib/rateLimit.ts`. The rate limiter keys Redis entries on `hashIp(extractClientIp(req))`. The `comments` table schema has no IP column. The `db.insert()` function takes a `NewCommentInput` (`postId`, `author`, `body`) and writes nothing else.
+
+### Finding: Raw IPs Never Reach the `comments` Table
+
+The `comments` table (defined in `lib/comments/db.ts`) contains:
+
+```
+id, post_id, author, body, created_at, status
+```
+
+No `ip` or `ip_hash` column exists. The `db.insert()` call only receives `postId`, `author`, and `body`. Raw IPs are not stored in Postgres at all — this is the better outcome.
+
+The IP is used only transiently: extracted from the request in `lib/rateLimit.ts`, hashed immediately, and used as a Redis key. It is not written to any durable store.
+
+### Acceptance Criteria
+
+- [ ] Grep confirms no raw IP write path exists in the codebase.
+- [ ] The decision not to store IPs (even hashed) in the DB is explicitly documented.
+- [ ] `lib/ipHash.ts` doc comment updated to reflect the current reality: IPs touch only Redis (as a hash), never Postgres.
+
+### Verification Commands
+
+Run these before closing 6B:
+
+```bash
+# Must return zero results — confirms no raw IP touches any insert call
+grep -rn "remoteAddress\|x-forwarded-for\|extractClientIp" pages/api/comments/ lib/comments/
+
+# Must return zero results — confirms no ip column in insert query
+grep -n "ip" lib/comments/db.ts
+```
+
+### Files to Change
+
+**`lib/ipHash.ts`** — update the module header comment to clarify the current flow:
+
+```diff
+- * The caller MUST pass the returned value through `hashIp`
+- * before writing it anywhere durable — this module cannot enforce that.
++ * The current implementation does NOT write IP data (raw or hashed) to
++ * Postgres. IPs are used only transiently as Upstash Redis keys (always
++ * hashed). This is a deliberate privacy decision documented in the Phase 6
++ * plan. If a future phase adds IP data to the DB for abuse investigation,
++ * it must use `hashIp` and must update this comment.
+```
+
+No schema change, no migration, no new env vars. This is a documentation-only task.
+
+### Risk / Trade-offs
+
+- **Not storing hashed IPs in DB** means we cannot retrospectively investigate abuse patterns. For a personal blog at low traffic this is an acceptable trade-off; the rate limiter handles live abuse.
+- **If abuse volume increases**, adding an `ip_hash` column to `comments` would be a small migration. The `hashIp` function is already in place to do so safely.
+
+### Dependencies
+
+None. Can land independently.
+
+### Rollout Notes
+
+Documentation update only. No deployment impact.
+
+---
+
+## 6C — Error Boundary
+
+### What Was Shipped
+
+`CommentsSection.js` already contains a fully functional React error boundary class (`CommentErrorBoundary`) that wraps `CommentsSectionInner`. It catches render-phase errors, logs them via `console.error`, and renders a fallback `role="alert"` paragraph.
+
+```js
+class CommentErrorBoundary extends Component {
+  static getDerivedStateFromError() { return { hasError: true }; }
+  componentDidCatch(err, info) { console.error("[CommentsSection] render error", err, info); }
+  render() { /* fallback or children */ }
+}
+```
+
+`CommentsSection` exports the boundary-wrapped component. The call site in `pages/posts/[id].js` uses `dynamic(import, { ssr: false })`, so the boundary is already in the lazy-loaded bundle.
+
+### Finding: This Sub-task Is Already Complete
+
+The error boundary from the implementation plan is implemented. The code matches the specified behaviour (class-based, fallback alert, `componentDidCatch` logging).
+
+### Acceptance Criteria (Verification Only)
+
+- [ ] `CommentsSection.js` exports a component whose root is `<CommentErrorBoundary>`.
+- [ ] `CommentErrorBoundary` renders `role="alert"` on error (not a blank section).
+- [ ] No `react-error-boundary` package was introduced (class-based boundary was used as specified — no new dependency).
+- [ ] A thrown error inside `CommentsSection` does not surface a Next.js error overlay in production (boundary catches it).
+
+### Files to Change
+
+None required. The boundary is already implemented.
+
+**Optional hardening:** Add a `data-testid="comments-error"` attribute to the fallback paragraph so Playwright can assert on it in a future error-injection test:
+
+```diff
+- <p role="alert" className="text-red-600 dark:text-red-400 text-base py-4">
++ <p role="alert" data-testid="comments-error" className="text-red-600 dark:text-red-400 text-base py-4">
+```
+
+### Risk / Trade-offs
+
+- **Class component vs react-error-boundary:** We used a class component. This is the correct choice — it avoids an extra dependency, is fully supported, and this component has no other reason to be a hooks component.
+- **Boundary granularity:** The boundary wraps the entire section. An alternative is a finer-grained boundary around only the list vs. the form. For a personal blog this granularity is sufficient; recovering the whole section on error is fine.
+
+### Dependencies
+
+None.
+
+### Rollout Notes
+
+No env vars. If the optional `data-testid` is added, ensure the 6E Playwright tests reference it.
+
+---
+
+## 6D — Analytics Events
+
+### What Was Shipped
+
+All three planned analytics events are already wired:
+
+| Event | Call site | Status |
+|---|---|---|
+| `comment_submitted` | `CommentForm.js` line 163: `track("comment_submitted")` | Shipped |
+| `comment_load_more` | `CommentList.js` line 54: `track("comment_load_more")` | Shipped |
+| `comment_deleted` | `CommentsSection.js` line 127: `track("comment_deleted")` | Shipped |
+
+`@vercel/analytics` is imported via `{ track }` in each component. `Analytics` is mounted in `pages/_app.js`.
+
+### Finding: Analytics Implementation Is Already Complete
+
+All three events specified in the implementation plan are live. No PII is included in any event property (no author name, no comment body, no IP, no email address in any `track()` call).
+
+### Acceptance Criteria (Verification Only)
+
+- [ ] `grep -rn "track(" components/comments/` returns all three call sites.
+- [ ] No event call passes PII as a property (grep for `.author`, `.body`, `.email` inside `track()` calls).
+- [ ] `@vercel/analytics` is listed in `package.json` dependencies (not devDependencies).
+- [ ] The Vercel Analytics dashboard (post-deploy) shows events arriving for each type after manual smoke test.
+
+### Proposed Event Property Schema (Confirmed No PII)
+
+For future reference, these are the exact shapes emitted:
+
+```js
+track("comment_submitted")    // no properties — count is the signal
+track("comment_load_more")    // no properties — count is the signal
+track("comment_deleted")      // no properties — count is the signal
+```
+
+Adding a `postId` property would be non-PII and could be useful for identifying which posts generate the most engagement. This is **optional** and deferred — adding it would require passing `postId` into `CommentList` and surfacing it in the `CommentsSection.handleDelete` closure. Log this as a future enhancement, not a Phase 6 blocker.
+
+### Files to Change
+
+None required.
+
+**Optional enhancement (not a blocker):** Add `postId` as a non-PII event property. If desired:
+
+```diff
+// CommentsSection.js — pass postId into track calls
+- track("comment_deleted");
++ track("comment_deleted", { postId });
+
+// CommentForm.js — postId is already a prop
+- track("comment_submitted");
++ track("comment_submitted", { postId });
+
+// CommentList.js — requires postId prop to be threaded down from CommentsSection
+- track("comment_load_more");
++ track("comment_load_more", { postId });
+```
+
+If you add `postId`, verify it is the post slug (not a database UUID) — slugs are public and non-PII.
+
+### Risk / Trade-offs
+
+- **No properties vs. postId:** Zero-property events are safe but produce only aggregate counts in the Vercel dashboard. Adding `postId` gives per-post funnel data. At current traffic levels, aggregate counts are sufficient.
+- **Analytics blocking:** `@vercel/analytics` uses a non-blocking pattern; `track()` is fire-and-forget and does not delay the UI interaction.
+
+### Dependencies
+
+None.
+
+### Rollout Notes
+
+No env vars. Analytics events only activate on Vercel deployments (the `Analytics` component in `_app.js` no-ops locally).
+
+---
+
+## 6E — Playwright E2E Expansion
+
+### What Was Shipped
+
+`tests/comments.spec.js` contains 12 scenarios (CMT-E2E-01 through CMT-E2E-12) covering:
+- Valid comment submit, link rejection, profanity rejection, empty-form validation
+- Pagination (show more), non-owner view, owner delete flow
+- Dark mode smoke, iPad Mini viewport, loading skeleton, server 500
+
+### Gap Analysis
+
+Cross-referencing the shipped spec against the Phase 6 requirements:
+
+| Scenario | Shipped? | Notes |
+|---|---|---|
+| Happy path submit | Yes (CMT-E2E-01) | |
+| Rate-limit UI (429 + countdown) | No | Missing |
+| Owner auth login flow | No | Missing |
+| Delete-by-token flow | No | Missing |
+| Owner sentinel cookie cleared on logout | No | Missing |
+| Error boundary fallback render | No | Optional, needs `data-testid` from 6C |
+
+### New Test Cases to Add
+
+Add to `tests/comments.spec.js` (or a new `tests/comments-advanced.spec.js` if the existing file becomes unwieldy):
+
+---
+
+#### CMT-E2E-13: Rate limiting — 429 response triggers countdown UI
+
+```js
+test("CMT-E2E-13: 429 response → rate-limit alert with countdown shown", async ({ page }) => {
+  // Stub GET
+  await page.route(`**/api/comments?**`, (route) => {
+    route.fulfill({ status: 200, contentType: "application/json",
+      body: JSON.stringify({ comments: [], total: 0 }) });
+  });
+  // Stub POST to return 429 with Retry-After
+  await page.route(`**/api/comments`, (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({
+        status: 429,
+        headers: { "Retry-After": "30" },
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: { code: "RATE_LIMIT", message: "Too many comments submitted." }
+        }),
+      });
+    }
+    route.continue();
+  });
+
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  await page.fill('[data-testid="comment-form"] input[name="author"]', "Alice");
+  await page.fill('[data-testid="comment-form"] textarea[name="body"]', "Valid comment");
+  await page.click('[data-testid="submit-comment"]');
+
+  // Rate-limit alert should be visible with countdown text
+  const alert = page.locator('[role="alert"]', { hasText: "Too many" });
+  await expect(alert).toBeVisible();
+
+  // Submit button should be disabled during rate-limit window
+  await expect(page.locator('[data-testid="submit-comment"]')).toBeDisabled();
+});
+```
+
+---
+
+#### CMT-E2E-14: Owner auth login → sentinel cookie set → delete buttons appear
+
+```js
+test("CMT-E2E-14: owner login sets sentinel cookie → delete buttons visible", async ({ page }) => {
+  const comment = makeComment({ id: "auth-test" });
+  await stubComments(page, { comments: [comment] });
+
+  // Stub the login endpoint to set the sentinel cookie
+  await page.route(`**/api/auth/login`, (route) => {
+    return route.fulfill({
+      status: 200,
+      headers: {
+        // Simulate the sentinel cookie being set by the server
+        "Set-Cookie": "owner_ui=1; Path=/; SameSite=Lax",
+      },
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true }),
+    });
+  });
+
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  // Before login: no delete buttons
+  await expect(page.locator('[data-testid="delete-comment"]')).toHaveCount(0);
+
+  // Simulate login by setting the cookie directly (equivalent to the login flow)
+  await page.addInitScript(() => {
+    document.cookie = "owner_ui=1; path=/";
+  });
+  // Reload so useEffect picks up the new cookie
+  await page.reload();
+
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+  await expect(page.locator('[data-testid="delete-comment"]')).toHaveCount(1);
+});
+```
+
+---
+
+#### CMT-E2E-15: Delete-by-token page — valid token shows comment preview, confirm deletes
+
+The delete-by-token flow uses `/owner/comments/delete?token=...` (a page added in Phase 5). This test exercises that page directly.
+
+```js
+test("CMT-E2E-15: delete-by-token page — valid token shows preview and confirms deletion", async ({
+  page,
+}) => {
+  const TOKEN = "valid.token.stub";
+  const COMMENT_ID = "deadbeef-0000-0000-0000-000000000001";
+
+  // Stub the token verification API (or the page's getServerSideProps equivalent)
+  // The exact route depends on the Phase 5 implementation — check
+  // pages/owner/comments/delete.js to confirm the fetch URL.
+  await page.route(`**/api/owner/delete-by-token**`, (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+    }
+    if (route.request().method() === "GET") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          comment: makeComment({ id: COMMENT_ID, author: "Bob", body: "Test body" }),
+        }),
+      });
+    }
+    route.continue();
+  });
+
+  await page.goto(`${BASE_URL}/owner/comments/delete?token=${TOKEN}`);
+
+  // Should show the comment preview
+  await expect(page.locator('[data-testid="delete-preview"]')).toBeVisible();
+  await expect(page.locator('[data-testid="delete-preview"]')).toContainText("Bob");
+
+  // Click confirm
+  await page.click('[data-testid="confirm-token-delete"]');
+
+  // Should navigate to or show a success state
+  await expect(page.locator('[data-testid="delete-success"]')).toBeVisible();
+});
+```
+
+**Note:** The exact `data-testid` attributes for the delete-by-token page need to be verified against the Phase 5 implementation in `pages/owner/`. If those `data-testid` attributes are missing from the page, add them as part of this task (not a separate phase).
+
+---
+
+#### CMT-E2E-16: Cancel delete — focus returns to delete button
+
+```js
+test("CMT-E2E-16: cancel inline delete — focus returns to delete button", async ({ page }) => {
+  const comment = makeComment({ id: "focus-test" });
+  await stubComments(page, { comments: [comment] });
+
+  await page.addInitScript(() => {
+    document.cookie = "owner_ui=1; path=/";
+  });
+
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="delete-comment"]')).toBeVisible();
+
+  // Open confirm
+  await page.click('[data-testid="delete-comment"]');
+  const cancelBtn = page.locator('button', { hasText: "Cancel" }).first();
+  await expect(cancelBtn).toBeVisible();
+
+  // Cancel
+  await cancelBtn.click();
+
+  // Confirm row should disappear
+  await expect(cancelBtn).not.toBeVisible();
+
+  // Focus should be back on the delete button
+  const deleteBtn = page.locator('[data-testid="delete-comment"]').first();
+  await expect(deleteBtn).toBeFocused();
+});
+```
+
+### Acceptance Criteria
+
+- [ ] All 12 existing CMT-E2E-01 through -12 pass against `localhost:3000`.
+- [ ] CMT-E2E-13 (rate limit countdown) passes.
+- [ ] CMT-E2E-14 (owner sentinel cookie) passes.
+- [ ] CMT-E2E-15 (delete-by-token) passes — requires `data-testid` attributes on the `/owner/comments/delete` page to be confirmed or added.
+- [ ] CMT-E2E-16 (cancel focus management) passes.
+- [ ] No test hits the real database (all API calls stubbed via `page.route()`).
+- [ ] All tests run against `http://localhost:3000` with dev server running (existing convention).
+
+### Files to Change
+
+- **`tests/comments.spec.js`** — append CMT-E2E-13, -14, -16.
+- **`tests/comments-advanced.spec.js`** (new, optional) — CMT-E2E-15 (delete-by-token) if the file grows large.
+- **`pages/owner/comments/delete.js`** (or `.tsx`) — add `data-testid="delete-preview"`, `data-testid="confirm-token-delete"`, `data-testid="delete-success"` if they are missing.
+
+### Risk / Trade-offs
+
+- **Stubbing vs. real flows:** CMT-E2E-14 simulates the login by directly setting the cookie rather than driving through the login UI. This is intentional — the login form is an admin-only page and its own test scope. What we care about here is that the sentinel cookie correctly gates the delete button UI.
+- **CMT-E2E-15 dependency on Phase 5 page structure:** The delete-by-token page was built in Phase 5. If `data-testid` attributes are missing, this test requires a minor code change to that page. Treat it as part of this task.
+
+### Dependencies
+
+- 6C (error boundary `data-testid`) for any error-boundary test.
+- 6D analytics events are already shipped, so no dependency there.
+- Phase 5's `/owner/comments/delete` page must exist (it does — it was part of Phase 5).
+
+### Rollout Notes
+
+No env vars. No deployment changes. Tests run locally before merge. Add to the CI job per the existing convention in `.github/workflows/`.
+
+---
+
+## 6F — Final Security Review
+
+### Scope
+
+This is a read-only audit pass — no code changes unless a blocker is found. The Phase 5 audit closed all Critical and High findings. Phase 6's audit verifies that the complete assembled system (all phases together, including the Phase 5 additions of Upstash, Resend, and HMAC delete tokens) has no regressions and confirms the overall posture before active promotion.
+
+### Checklist
+
+Run each check in order. Mark pass/fail.
+
+#### Group 1 — Data Handling
+
+| # | Check | Command | Pass condition |
+|---|---|---|---|
+| D-1 | No raw IP in DB | `grep -rn "remoteAddress\|x-forwarded-for\|extractClientIp" lib/comments/ pages/api/comments/` | Zero results |
+| D-2 | No raw IP in Redis key | Read `lib/rateLimit.ts` — `checkLimit()` must call `hashIp()` before `ratelimiter.limit()` | `hashIp` call precedes `limit()` call |
+| D-3 | No IP column in insert query | `grep -n "ip" lib/comments/db.ts` | Zero results matching a column name |
+| D-4 | Comment body stored post-sanitisation | Read `pages/api/comments/index.ts` — `db.insert()` receives `parsed.data.body` (Zod-parsed) | Zod parse precedes `db.insert()` |
+| D-5 | No email stored | `grep -n "email" lib/comments/db.ts lib/comments/types.ts` | Zero results in `db.ts`; `types.ts` may reference it only in comments |
+
+#### Group 2 — Input Handling
+
+| # | Check | Command | Pass condition |
+|---|---|---|---|
+| I-1 | No `dangerouslySetInnerHTML` in comment components | `grep -rn "dangerouslySetInnerHTML" components/comments/` | Zero results |
+| I-2 | Link rejection is server-authoritative | Read `pages/api/comments/index.ts` — Zod schema with `URL_RE` refine runs server-side | Present |
+| I-3 | Profanity check before insert | Read `pages/api/comments/index.ts` — `containsProfanity()` called before `db.insert()` | Correct order |
+| I-4 | Body length cap enforced server-side | `grep -n "max(1000)" lib/comments/schema.ts` | Present |
+| I-5 | Honeypot checked before Zod parse | Read `pages/api/comments/index.ts` — `body.url` check in step 2, Zod in step 3 | Correct order |
+| I-6 | Parameterised queries only | `grep -n "sql\`" lib/comments/db.ts` — all DB calls use tagged template literals | Present; no string concatenation |
+
+#### Group 3 — Auth & Session
+
+| # | Check | Command | Pass condition |
+|---|---|---|---|
+| A-1 | DELETE requires owner session | Read `pages/api/comments/[id].ts` — `session.isOwner !== true` check before UUID parse | Present |
+| A-2 | Origin check on DELETE | `grep -n "verifyOrigin" pages/api/comments/[id].ts` | Present |
+| A-3 | CSRF check on DELETE | `grep -n "verifyCsrf" pages/api/comments/[id].ts` | Present |
+| A-4 | No localStorage auth | `grep -rn "localStorage" lib/ pages/api/` | Zero results |
+| A-5 | Iron Session cookie flags | Read `lib/auth.ts` — `httpOnly: true, secure: true, sameSite: "lax"` | All three present |
+| A-6 | `IRON_SESSION_PASSWORD` ≥ 32 chars | Check `.env.example` comment and Vercel prod env | Min length enforced |
+| A-7 | Delete-by-token uses `timingSafeEqual` | Read `lib/deleteToken.ts` | `crypto.timingSafeEqual` present |
+| A-8 | Delete token expiry AND signature both checked | Read `lib/deleteToken.ts` `verifyDeleteToken` | Both checks unconditional (no early return before sig compare) |
+
+#### Group 4 — Rate Limiting & Spam
+
+| # | Check | Command | Pass condition |
+|---|---|---|---|
+| R-1 | Rate limit checked FIRST in POST handler | Read `pages/api/comments/index.ts` — `checkLimit()` is step 1 | Present |
+| R-2 | Rate limit fail-open (not fail-closed) | Read `lib/rateLimit.ts` — catch blocks return `{ allowed: true }` | Present (intentional for personal blog) |
+| R-3 | `Retry-After` header set on 429 | Read `pages/api/comments/index.ts` — `res.setHeader("Retry-After", ...)` | Present |
+| R-4 | `IP_HASH_SALT` minimum length enforced | Read `lib/ipHash.ts` — `MIN_IP_HASH_SALT_LENGTH = 16` | Present |
+
+#### Group 5 — Email
+
+| # | Check | Command | Pass condition |
+|---|---|---|---|
+| E-1 | Email failure does not fail comment POST | Read `pages/api/comments/index.ts` — `notifyOwnerOfComment` in try/catch, 201 still returned | Present |
+| E-2 | No commenter email stored | `grep -rn "email" lib/comments/` | Zero results for a stored field |
+| E-3 | Email uses Resend SDK (not raw SMTP construction) | Read `lib/mail.ts` — Resend client used | Present |
+| E-4 | Rate limit runs before email call | Read `pages/api/comments/index.ts` — `checkLimit()` in step 1, email in step 6 | Correct order |
+
+#### Group 6 — Secrets & Config
+
+| # | Check | Command | Pass condition |
+|---|---|---|---|
+| S-1 | All secrets in `.env.example` with placeholder values | `cat .env.example` — all vars listed | Present |
+| S-2 | No secrets in git history | `git log -p --follow -- .env*` | No real key values |
+| S-3 | Vercel env var scoping | Vercel dashboard — `DATABASE_URL`, `RESEND_API_KEY`, `OWNER_PASSWORD`, `IRON_SESSION_PASSWORD` scoped to Production only | Confirmed in dashboard |
+| S-4 | `DELETE_TOKEN_SECRET` ≥ 32 chars | Read `lib/deleteToken.ts` `MIN_SECRET_LENGTH` | 32 |
+
+#### Group 7 — Analytics PII
+
+| # | Check | Command | Pass condition |
+|---|---|---|---|
+| P-1 | No PII in track() calls | `grep -n "track(" components/comments/` — review each call site | No `.author`, `.body`, `.email`, IP in properties |
+
+### Findings Format
+
+For any item that does not pass, record:
+
+```
+[CHECK ID] — FAIL
+Location: <file>:<line>
+Issue: <one sentence>
+Remediation: <one sentence>
+Blocking? Yes/No
+```
+
+Phase 6 ships only after all items marked "Blocking" are resolved. Items marked "No" can be tracked as follow-up issues.
+
+### Acceptance Criteria
+
+- [ ] All "Blocking" checks pass.
+- [ ] Findings documented in a comment on the Phase 6 PR.
+- [ ] No new Critical or High findings versus the Phase 5 audit baseline (0C/0H).
+
+### Files to Change
+
+None unless a blocker is found. If a blocker is found, the remediation is scoped to the specific file identified.
+
+### Dependencies
+
+- 6B must complete first (IP hashing verification is an input to checks D-1 through D-3).
+- Should be run after 6A, 6C, and 6D land so the audit covers the final state of all files.
+
+### Rollout Notes
+
+No env vars. No deployment changes. This is a pre-merge gate.
+
+---
+
+## Summary: What Each Wave Delivers
+
+| Wave | Tasks | Deliverable |
+|---|---|---|
+| 1 | 6A, 6B, 6F (start) | Accurate privacy copy; IP handling formally verified and documented; security audit in progress |
+| 2 | 6C (verify + optional testid), 6D (verify) | Error boundary confirmed with testable attribute; analytics confirmed clean |
+| 3 | 6E, 6F (complete) | Full E2E suite covering rate limiting, auth flow, token delete, focus management; security audit signed off |
+
+After Wave 3: merge to `main`, deploy to Vercel production, run manual smoke tests (submit a real comment, receive the Resend notification, click the one-click delete token link, verify the Vercel Analytics dashboard shows events), then promote the feature.
+
+---
+
+## Environment Variables — Final Inventory
+
+All of these must be set in Vercel (Production scope) before promotion:
+
+| Variable | Purpose | Phase introduced |
+|---|---|---|
+| `DATABASE_URL` | Neon Postgres connection string | 1 |
+| `UPSTASH_REDIS_REST_URL` | Upstash Redis endpoint | 5 |
+| `UPSTASH_REDIS_REST_TOKEN` | Upstash Redis auth token | 5 |
+| `RESEND_API_KEY` | Resend transactional email | 5 |
+| `OWNER_NOTIFY_EMAIL` | Address to receive notifications | 5 |
+| `OWNER_FROM_EMAIL` | Verified Resend sender address | 5 |
+| `OWNER_PASSWORD` | Iron Session login password (≥ 32 chars) | 3 |
+| `IRON_SESSION_PASSWORD` | Iron Session cookie encryption key (≥ 32 chars) | 3 |
+| `IP_HASH_SALT` | HMAC salt for IP anonymisation (≥ 16 chars) | 5 |
+| `DELETE_TOKEN_SECRET` | HMAC key for one-click delete tokens (≥ 32 chars) | 5 |
+| `NEXT_PUBLIC_SITE_URL` | Canonical origin for CSRF origin check | 3 |
+
+No new env vars are introduced in Phase 6.

--- a/docs/comments-phase-6-qa-plan.md
+++ b/docs/comments-phase-6-qa-plan.md
@@ -1,0 +1,307 @@
+# Comments Feature — Phase 6 QA Plan
+
+**Phase 6 scope:** Privacy notice copy, IP hashing verification, React error boundaries, Vercel Analytics events, full Playwright E2E coverage, pre-launch security review.
+
+**Goal:** "I'm comfortable leaving this running unattended on `main` for months."
+
+---
+
+## 1. Coverage Gap Analysis
+
+### What exists today
+
+**Unit tests** (Vitest, `tests/unit/`) — 7 files, all in good shape:
+
+| File | What it covers |
+|---|---|
+| `schema.test.js` | `NewCommentSchema` — 15 cases, boundary + link refinement |
+| `hasLinks.test.js` | `lib/comments/sanitize.ts` |
+| `containsProfanity.test.js` | `lib/comments/profanity.ts` |
+| `isOwner.test.js` | `lib/auth.ts` — 6 cases including password-length guard |
+| `deleteToken.test.js` | `lib/deleteToken.ts` — 8 cases including oracle-prevention |
+| `rateLimit.test.js` | `lib/rateLimit.ts` — 7 cases including fail-open |
+| `ipHash.test.js` | `lib/ipHash.ts` — 9 cases |
+
+**Integration tests** (Vitest, `tests/integration/`) — 2 files:
+
+- `comments-api.test.js`: GET-01–05, POST-01–10, DELETE-01–07 — mocks DB, mail, auth, rateLimit
+- `comments-api-phase5.test.js`: P5-01–05 — uses real `lib/rateLimit` + `lib/mail`, mocks only external SDKs
+
+**E2E tests** (Playwright, `tests/comments.spec.js`) — 12 scenarios, CMT-E2E-01 through CMT-E2E-12. All API calls are stubbed via `page.route()`.
+
+### Confirmed gaps — what is NOT tested
+
+The following items have zero test coverage and represent launch risk.
+
+**Gap 1 — Analytics events (all three) — CRITICAL**
+`track("comment_submitted")` fires in `CommentForm.js` line 163. `track("comment_load_more")` fires in `CommentList.js` line 54. `track("comment_deleted")` fires in `CommentsSection.js` line 127. None are exercised in the E2E suite. A regression here (import removed, call moved into wrong branch) would silently drop analytics without any test catching it. These must be intercepted at the network layer.
+
+**Gap 2 — Character counter live region (aria-live="polite") — HIGH**
+`CommentForm.js` lines 362–366 render `<p aria-live="polite">` which only announces at the thresholds 100, 50, 20, and 0. There is no E2E test confirming the threshold logic fires correctly or that the visible counter updates on every keystroke.
+
+**Gap 3 — Honeypot field browser-layer behaviour — HIGH**
+POST-07 in the integration suite verifies the server silently discards a filled honeypot. But there is no E2E test verifying the honeypot field is: (a) not visible to real users, (b) not in the tab order, and (c) not filled by the browser's own autofill. A regression in the `sr-only` + `tabIndex={-1}` + `autoComplete="off"` attributes would expose the trap to real users.
+
+**Gap 4 — Rate-limit countdown UI — MEDIUM**
+`CommentForm.js` lines 73–87 implement a `retryCountdown` interval that ticks down from `retryAfter` seconds and re-enables the form when it hits zero. No E2E test verifies the countdown renders, decrements, or that the form becomes re-submittable afterwards.
+
+**Gap 5 — Owner login flow (admin page) — HIGH**
+`pages/admin.js` has no Playwright tests at all. The owner must log in before the in-page delete UI (CMT-E2E-07) is meaningful in production. There are no tests for wrong password, successful login, cookie set, or the logout path.
+
+**Gap 6 — Token confirmation page (delete-by-token) — HIGH**
+`pages/owner/comments/delete.js` has no E2E coverage. The four token states (`VALID`, `EXPIRED`, `BAD_SIGNATURE`, `MALFORMED`) are exercised in unit tests for the library function but the rendered page for each state is never tested. The POST-on-confirm flow (the `handleDelete` function) is completely untested end-to-end.
+
+**Gap 7 — Error boundary — MEDIUM**
+`CommentsSection.js` wraps the inner component in `CommentErrorBoundary` (lines 39–67). There is no test confirming that a render error is caught and that the fallback renders without breaking the rest of the post page.
+
+**Gap 8 — Accessibility audit (axe) — HIGH**
+No automated accessibility audit runs against the post page with comments visible. The form has `role="alert"`, `aria-describedby`, `aria-live`, `aria-required`, `aria-label` on the delete button, and `role="group"` on the confirm row. Any one of these could be mis-wired without a test catching it.
+
+**Gap 9 — Privacy notice text — LOW**
+`CommentForm.js` line 229 renders the privacy notice. No test asserts the text is present. Easy to accidentally delete in a refactor.
+
+**Gap 10 — `api/comments/[id].ts` DELETE route not covered by any E2E — MEDIUM**
+CMT-E2E-07 stubs `DELETE /api/comments/delete-me` directly. The real `[id].ts` route handler is exercised by integration tests (with mocked DB) but never by a real HTTP call. There is no test that hits the actual Next.js API route without mocking.
+
+**Gap 11 — `api/owner/delete-by-token.ts` — no integration test using real handler logic**
+The route handler in `pages/api/owner/delete-by-token.ts` has no integration test equivalent to the comments-api tests. Token verification and DB calls are only tested in isolation (unit) or end-to-end (page). The middle layer — the route handler receiving a POST with a token — is untested.
+
+**Gap 12 — CI workflow runs Playwright only, not Vitest**
+`tests.yml` runs `npx playwright test`. The `npm run test:unit` (Vitest) command is not in the workflow. Unit + integration tests only run locally.
+
+---
+
+## 2. Phase 6 E2E Test Plan
+
+The following 20 tests complete the suite to launch quality. They are authored in `tests/comments.spec.js` as additional scenarios extending CMT-E2E-01 through CMT-E2E-12.
+
+All new tests follow the existing conventions: `page.route()` stubs before `page.goto()`, `data-testid` selectors, `POST_SLUG = "2025-01-30-scrum"`.
+
+---
+
+### Tabular test plan
+
+| ID | Description | Preconditions → Actions → Assertions | Data setup / teardown | Phase feature | Priority |
+|---|---|---|---|---|---|
+| **CMT-E2E-13** | Character counter updates on every keystroke | Stub GET (empty), navigate to post. Focus body textarea. Type 900 characters one keystroke at a time (use `fill` for speed). | `page.route` GET stub; no DB | Phase 1 form UX | P1 |
+| | | Assert visible counter shows "100 remaining". Type 50 more characters. Assert counter shows "50 remaining" with neutral style. Type 30 more. Assert counter shows "20 remaining" with red style. | None | | |
+| **CMT-E2E-14** | Character counter polite live region announces at thresholds | Stub GET (empty), navigate to post. Fill body to reach exactly 900 chars (100 remaining). | `page.route` GET stub; no DB | Phase 6 a11y | P1 |
+| | | Assert `[aria-live="polite"].sr-only` contains "100 characters remaining". Fill to 950 (50 remaining). Assert the live region now reads "50 characters remaining". Verify visible counter `#body-char-count` also updates. | None | | |
+| **CMT-E2E-15** | Honeypot field is invisible and removed from tab order | Stub GET (empty), navigate to post. | `page.route` GET stub; no DB | Phase 1 security | P1 |
+| | | Assert `input[name="url"]` is attached to DOM. Assert `input[name="url"]` has `tabIndex` of `-1` (via `getAttribute`). Assert `input[name="url"]` is NOT visible (`.isVisible()` returns false). Assert `autoComplete` attribute is `"off"`. Fill author + body. Tab through the form. Assert focus never lands on the url field. | None | | |
+| **CMT-E2E-16** | Honeypot filled → server 200 silent discard, no comment added | Override POST stub to return 200 with no `comment` body (mirroring server behaviour for honeypot). Directly set `input[name="url"]` value via `page.evaluate`. Submit form with author + body. | `page.route` GET + POST stubs | Phase 1 security | P0 |
+| | | Assert `[data-testid="comment-item"]` count remains 0. Assert no `role="status"` success announcement. Assert no `role="alert"` error. | None | | |
+| **CMT-E2E-17** | Rate-limit 429 → alert with countdown, form disabled, re-enables after countdown | Override POST stub to return 429 with `Retry-After: 3` header and `{ error: { code: "RATE_LIMIT" } }`. Fill author + body. Submit. | `page.route` GET + POST stubs | Phase 5 rate limiting | P0 |
+| | | Assert `role="alert"` visible with "Too many submissions" text. Assert countdown element renders (text includes "s"). Assert submit button is disabled. Wait 4 seconds. Assert submit button is no longer disabled. Assert `role="alert"` has disappeared. | No real DB or email | | |
+| **CMT-E2E-18** | `comment_submitted` analytics event fires on successful submit | Intercept all outbound requests matching `**/v1/vitals` or `**/api/send-event` with `page.route`. OR use `page.on("request", …)` to capture beacon calls to `va.vercel-insights.com`. Fill author + body. Submit. | `page.route` GET + POST stubs; analytics beacon route intercept | Phase 6 analytics | P1 |
+| | | Assert at least one intercepted request body (or URL) contains `"comment_submitted"`. | None | | |
+| **CMT-E2E-19** | `comment_load_more` analytics event fires when Show more is clicked | Stub GET with 7 comments. Navigate. Intercept analytics beacons. Click `[data-testid="show-more"]`. | `page.route` GET stub (7 comments); analytics beacon intercept | Phase 6 analytics | P1 |
+| | | Assert at least one intercepted request body contains `"comment_load_more"`. Assert all 7 `[data-testid="comment-item"]` are visible. | None | | |
+| **CMT-E2E-20** | `comment_deleted` analytics event fires after owner deletes | Stub GET (1 comment), stub DELETE, set `owner_ui=1` cookie, navigate. Intercept analytics beacons. Click delete → confirm. | `page.route` stubs; analytics beacon intercept; cookie | Phase 6 analytics | P1 |
+| | | Assert at least one intercepted request body contains `"comment_deleted"`. Assert `[data-testid="comment-item"]` count is 0. | None | | |
+| **CMT-E2E-21** | Error boundary: render error in CommentsSection does not break post page | Navigate to post. After mount, use `page.evaluate` to throw an error inside the comments section by removing a required prop or calling a React render helper that throws. | `page.route` GET + POST stubs | Phase 6 error boundary | P0 |
+| | | Assert the rest of the post page body content is still visible (e.g. the `<h1>` of the post). Assert `role="alert"` is visible containing "Comments could not be loaded". Assert the comment form is NOT present (the boundary caught the section). | None | | |
+| **CMT-E2E-22** | Token confirmation page — valid token shows comment preview and delete button | Stub `GET /api/comments?…` and stub `page.route("**/owner/comments/delete*"…)` — actually this page is server-rendered so navigate to `/owner/comments/delete?token=<valid-token>`. Stub `/api/owner/delete-by-token` to return 200. | Use a freshly-signed token generated server-side OR inject `getServerSideProps` return via route mock for the page itself — see isolation note below. Simpler: navigate to the page with a known-good token and stub only the POST endpoint. | Phase 5 delete-by-token | P0 |
+| | | Assert heading "Delete comment" is visible. Assert comment preview card is visible (contains `commentPreview.author` text). Assert "Delete comment" button is enabled. Click it. Assert `role="status"` with "Comment deleted. You can close this tab." is visible. | None | | |
+| **CMT-E2E-23** | Token confirmation page — expired token shows error message | Navigate to `/owner/comments/delete?token=<expired-token>`. | Expired token is a token whose timestamp part has been replaced with a past value (or use `signDeleteToken` in a helper script with a backdated system time). | Phase 5 delete-by-token | P0 |
+| | | Assert `role="alert"` is visible containing "expired". Assert no comment preview card is rendered. Assert no delete button is rendered. | None | | |
+| **CMT-E2E-24** | Token confirmation page — malformed token shows error message | Navigate to `/owner/comments/delete?token=not-a-valid-token`. | No setup needed — the URL itself is the input | Phase 5 delete-by-token | P0 |
+| | | Assert `role="alert"` is visible. Assert it does not contain the word "expired" (distinguishable from CMT-E2E-23). Assert no delete button. | None | | |
+| **CMT-E2E-25** | Token confirmation page — bad signature shows error message | Navigate to `/owner/comments/delete?token=<tampered-token>` where one segment has been base64url-replaced. | Craft a tampered token in the test itself using `Buffer.from(…).toString("base64url")` | Phase 5 delete-by-token | P1 |
+| | | Assert `role="alert"` containing "not valid". Assert no delete button. | None | | |
+| **CMT-E2E-26** | Admin login — wrong password shows error, correct password sets cookie | Navigate to `/admin`. Assert password field is focused. Submit with wrong password. | Stub `POST /api/auth/login` to return `401 { error: "Wrong password" }` for the wrong attempt, then `200 { ok: true }` with `Set-Cookie: owner_ui=1` for the correct attempt. | Phase 3 owner auth | P1 |
+| | | After wrong password: assert `role="alert"` visible with error text. After correct password (re-fill + submit): assert page shows logged-in state (logout button visible, password form gone). | No real password needed — stubs control the response | | |
+| **CMT-E2E-27** | Accessibility audit — post page with comments passes axe-core | Stub GET with 3 comments (including one with a long body). Navigate to post. Wait for `[data-testid="comment-form"]` to be visible. | `page.route` GET stub (3 comments) | Phase 6 a11y | P1 |
+| | | Run `@axe-core/playwright` `checkA11y` on the full page. Assert zero violations at impact level `critical` or `serious`. | None — axe scans the live DOM | | |
+| **CMT-E2E-28** | Accessibility audit — post page with delete confirm row open | Stub GET (1 comment), set `owner_ui=1` cookie, navigate. Wait for comment. Click `[data-testid="delete-comment"]`. Wait for `[data-testid="confirm-delete"]` to be visible. | `page.route` stub; cookie | Phase 6 a11y | P1 |
+| | | Run `checkA11y`. Assert zero critical/serious axe violations. Specifically verify `role="group"` + `aria-label="Confirm deletion"` passes. | None | | |
+| **CMT-E2E-29** | Privacy notice text is present above the form | Stub GET (empty), navigate to post. | `page.route` GET stub | Phase 6 privacy notice | P1 |
+| | | Assert `[data-testid="comment-form"]` contains text matching "Comments are public". Assert the notice paragraph is visible (not `sr-only`). | None | | |
+| **CMT-E2E-30** | Rate-limit e2e — 5 rapid POSTs succeed, 6th returns 429 alert | This test exercises the real API if run against the dev server, which risks sending real emails. **See Section 4 — use `DISABLE_EMAIL=1` env flag.** Stub POST to return 201 for the first 5 calls and 429 (with `Retry-After: 10`) for the 6th call using a stateful counter inside the `page.route` handler. | Stateful `page.route` with a call counter variable in the test closure. No real DB needed. | Phase 5 rate limiting | P0 |
+| | | After 5 successful submissions: assert 5 `[data-testid="comment-item"]` visible. Submit 6th. Assert `role="alert"` visible with rate-limit message. Assert submit button disabled. | `page.route` counter resets on test teardown | | |
+| **CMT-E2E-31** | Delete confirm — Cancel restores focus to delete button | Stub GET (1 comment), set `owner_ui=1` cookie, navigate. Click `[data-testid="delete-comment"]`. Assert confirm row visible. Click "Cancel". | `page.route` stub; cookie | Phase 3 owner delete | P1 |
+| | | Assert confirm row is gone. Assert `[data-testid="delete-comment"]` is visible. Assert `document.activeElement` equals the delete button (check via `page.evaluate(() => document.activeElement?.dataset?.testid)`). | None | | |
+
+---
+
+## 3. Test Isolation Strategy
+
+### The problem
+The backend is a real Neon Postgres database. Running E2E tests that hit the live DB risks:
+- Leaving test comments in production data
+- Tests depending on existing rows that may be modified or deleted by other tests
+- Email to the real owner inbox on every successful POST
+
+### Options evaluated
+
+**Option A — Neon branch per test run**
+Neon supports branching from the production schema. CI creates a branch, runs tests, drops the branch. Clean isolation. The developer experience for local runs is poor (requires Neon CLI, branch creation is ~3 seconds, and the branch URL must be injected as `DATABASE_URL` at test time). Adds CI complexity.
+
+**Option B — DB cleanup hooks**
+After each test that writes data, issue a DELETE to clean up. Fragile: if a test aborts mid-run, cleanup never executes and the DB accumulates state. Not recommended.
+
+**Option C — Seeded fixture posts + `page.route()` stubs for all API calls** (RECOMMENDED)
+All current Playwright tests already do this. `page.route("**/api/comments?**", …)` intercepts the GET; `page.route("**/api/comments", …)` intercepts the POST. The test never touches the real DB. This is the right architecture for a personal blog at low traffic — no Neon branching overhead, tests run entirely in-process against the Next.js server, and all assertions are against stubbed data.
+
+For the token confirmation page tests (CMT-E2E-22 through CMT-E2E-25), the page is server-rendered via `getServerSideProps` which calls the real DB. The isolation strategy here is: stub `/api/owner/delete-by-token` (the POST action) via `page.route`, and for the `getServerSideProps` DB call, either:
+- Use `page.route` on the page URL itself with a custom response (not practical for SSR)
+- **Better**: add a thin seam — accept a `?_mock=1` query param in `getServerSideProps` during `NODE_ENV=test` that returns hardcoded `commentPreview` data without a DB call.
+
+**Option D — CI-only secondary Neon database**
+A separate Neon project with a clean schema, pointed to by `TEST_DATABASE_URL` in GitHub Actions secrets. Integration tests that need a real DB (the Vitest integration tests) can target this. E2E tests still use stubs. This is worth adding for the Vitest integration layer but is out of Phase 6 scope for E2E.
+
+### Recommendation
+Keep all E2E tests fully stubbed via `page.route()` (Option C, which is already the convention). Add a `NODE_ENV=test` seam to `getServerSideProps` in `pages/owner/comments/delete.js` to avoid the DB call in token page tests. If a future phase adds integration-level E2E that must hit a real DB, adopt Option D at that point.
+
+---
+
+## 4. Rate-Limit Testing Without Email Spam
+
+### The problem
+Phase 5 sends a notification email via Resend on every successful `POST /api/comments`. Any E2E test that submits 5+ real comments to the API (to trigger the 429 on the 6th) will send up to 5 emails to the real owner inbox.
+
+### Options evaluated
+
+**Option A — Resend test mode API key** (`re_test_…`)
+Resend's test-mode API key accepts sends without delivering email. This is the cleanest real-world option. Requires maintaining a separate key in CI secrets and ensuring `RESEND_API_KEY` is set to the test key in the test environment.
+
+**Option B — `DISABLE_EMAIL=true` env flag**
+Add a guard in `lib/mail.ts`: if `process.env.DISABLE_EMAIL === "true"`, return early without calling `resend.emails.send`. Set this flag in the Playwright CI job. No extra Resend account needed. The cost is a small amount of test-only branching in the production module.
+
+**Option C — Mock at the network layer (stub the API)**
+CMT-E2E-30 already uses `page.route` to stub the POST endpoint, so the handler never runs and no email is sent. This means the rate-limit E2E test does not exercise the real rate-limit logic at all — it only exercises the UI's response to a 429. That is acceptable for an E2E test; the real rate-limit logic is proven in the Vitest integration tests (P5-01 through P5-04).
+
+**Option D — Honeypot trick (submit with filled honeypot)**
+Fill the honeypot field for test submissions. The server silently discards the comment but returns 200, so the rate limiter is never triggered. This does not test the 429 path at all.
+
+### Recommendation
+**Option C** for E2E (already the convention — stubs prevent any real emails). **Option A** (Resend test key) for the Vitest integration tests that call the real `lib/mail.ts`. Set `RESEND_API_KEY=re_test_…` in GitHub Actions for the `test:unit` step. This means no code changes to production modules and no divergence between test and production code paths.
+
+If Option A (separate Resend key) is not worth the operational overhead, **Option B** is the fallback: one env-guarded early return in `lib/mail.ts` is a low-risk change and is better than Option D which does not test anything useful.
+
+---
+
+## 5. CI Considerations
+
+### Current state
+`tests.yml` runs on every push and every PR. It:
+1. Builds the Next.js app (`npm run build`)
+2. Starts the production server (`npm run start &`)
+3. Waits for port 3000
+4. Runs `npx playwright test`
+
+**Vitest unit and integration tests are not run in CI.** `npm run test:unit` is absent from the workflow. This is the most important gap to close in Phase 6.
+
+### What to add for Phase 6
+
+**Step 1 — Add Vitest to CI**
+
+Add a `test-unit` job before the Playwright job:
+
+```yaml
+test-unit:
+  runs-on: ubuntu-22.04
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20.9.0
+        cache: npm
+    - run: npm ci
+    - run: npm run test:unit
+  env:
+    DELETE_TOKEN_SECRET: ${{ secrets.DELETE_TOKEN_SECRET }}
+    IRON_SESSION_PASSWORD: ${{ secrets.IRON_SESSION_PASSWORD }}
+    IP_HASH_SALT: ${{ secrets.IP_HASH_SALT }}
+    UPSTASH_REDIS_REST_URL: ${{ secrets.UPSTASH_REDIS_REST_URL }}
+    UPSTASH_REDIS_REST_TOKEN: ${{ secrets.UPSTASH_REDIS_REST_TOKEN }}
+    RESEND_API_KEY: ${{ secrets.RESEND_API_KEY_TEST }}
+    OWNER_NOTIFY_EMAIL: test@example.com
+    OWNER_FROM_EMAIL: test@example.com
+    NEXT_PUBLIC_SITE_URL: http://localhost:3000
+```
+
+Note: the integration tests already mock the Upstash and Resend SDKs, so the real Upstash/Resend credentials are not used. Only `DELETE_TOKEN_SECRET`, `IRON_SESSION_PASSWORD`, and `IP_HASH_SALT` are load-bearing — the rest can be dummy values. Use GitHub Actions secrets for the real values.
+
+**Step 2 — Upgrade Playwright job to depend on test-unit**
+
+Add `needs: test-unit` to the playwright job so a unit test failure blocks E2E rather than running both in parallel against a broken build.
+
+**Step 3 — Add axe-core/playwright**
+
+Install `@axe-core/playwright` as a devDependency. The accessibility E2E tests (CMT-E2E-27, CMT-E2E-28) import it directly — no extra CI step needed beyond the existing Playwright job. The package is ~200 KB and does not require a running server beyond what is already started.
+
+**Step 4 — Upgrade checkout and setup-node actions**
+
+The current workflow uses `actions/checkout@v2` and `actions/setup-node@v3`. These are several major versions behind. Upgrade to `@v4` for both. This is a correctness issue — `@v2` does not support caching and has open CVEs.
+
+**Step 5 — (Optional) `webServer` in playwright.config.js**
+
+The current config has `webServer` commented out. Enabling it lets Playwright start and manage the server lifecycle automatically, eliminating the manual `npm run start &` + `nc` wait loop in `tests.yml`. This is a reliability improvement, not a correctness requirement.
+
+### Should we gate merges on axe-core failures?
+
+**Yes, gate on critical and serious violations. No, do not gate on moderate or minor.**
+
+Reasoning: critical and serious axe violations (missing `alt`, unlabelled form controls, low colour contrast at the system level) are objectively broken from an accessibility standpoint. They are binary — either the ARIA attribute exists or it doesn't. They are also cheap to fix immediately and expensive to accumulate. Allowing these through on a PR means they ship to production where they may be indexed by search engines and screenshotted by real assistive technology.
+
+Moderate and minor violations are more contextual (reading order, redundant ARIA, landmark region suggestions) and often require design judgement. Gating on these will cause friction and discourages adoption of the axe step entirely.
+
+Implementation: pass `{ runOnly: { type: "tag", values: ["wcag2a", "wcag2aa", "wcag21aa"] }, resultTypes: ["violations"] }` to `checkA11y` and filter to `impact === "critical" || impact === "serious"` before asserting. This is the right policy for a personal site that is not under active accessibility litigation but wants to avoid obvious failures.
+
+---
+
+## 6. Pre-Launch Smoke Test Checklist
+
+Run this manually against production after deploying Phase 6. These are things automation cannot verify.
+
+1. **Real email delivery** — Submit a comment on a production post. Confirm the notification email arrives at your inbox within 60 seconds. Verify the delete link in the email is clickable.
+
+2. **Delete-by-token flow — real email** — Click the delete link from the email. Confirm `/owner/comments/delete?token=…` loads with the comment preview. Click Delete. Confirm the success message "Comment deleted. You can close this tab." appears. Reload the post and confirm the comment is gone.
+
+3. **Owner login — real credentials** — Navigate to `/admin`. Log in with the real `OWNER_PASSWORD`. Confirm the `owner_ui=1` cookie is set. Reload a post page. Confirm delete buttons appear on all comments.
+
+4. **Delete via in-page button — logged in** — Use the owner session to delete a comment using the trash icon on a post page. Confirm the comment disappears and the "Comment deleted" screen-reader announcement fires.
+
+5. **Rate limit — real threshold** — Submit 5 comments on the same post in rapid succession (different author names, same IP). On the 6th, confirm the 429 alert renders with the countdown. Do not submit more — this sends 5 real emails.
+
+6. **Profanity filter — real submission** — Submit a comment containing a word from the `bad-words` default list. Confirm the 422 alert renders correctly. Confirm no email was sent (no new email arrives).
+
+7. **Privacy notice visible on mobile** — On a real iPhone (or Chrome DevTools mobile emulation at 390px), navigate to a post and scroll to the comment form. Confirm the privacy notice is fully visible above the form, not clipped.
+
+8. **iPad Mini portrait — no overflow** — On a real iPad Mini or emulated 768×1024 viewport, verify no horizontal scroll bar appears on the post page with comments loaded.
+
+9. **Dark mode — comment form contrast** — Toggle dark mode. Verify the comment form fields, labels, and error states are readable (no white-on-white or black-on-black scenarios).
+
+10. **Analytics dashboard** — After submitting a test comment and loading the page, check the Vercel Analytics dashboard to confirm `comment_submitted` appears as a custom event. Verify `comment_load_more` appears after clicking Show more on a post with more than 5 comments.
+
+11. **`robots` meta on token page** — Navigate to `/owner/comments/delete?token=anything`. View page source. Confirm `<meta name="robots" content="noindex, nofollow" />` is present.
+
+12. **`noindex` on admin page** — Navigate to `/admin`. View page source. Confirm `noindex, nofollow` meta tag is present.
+
+13. **IP hash — no raw IPs in DB** — After receiving a real comment, query the `comments` table directly. Confirm no `ip` column contains a raw IP address (the column should contain a 64-char hex hash or be absent entirely).
+
+14. **Expired token message** — Manually craft a token with a past timestamp (use the `signDeleteToken` utility with `vi.useFakeTimers` or edit the timestamp segment). Navigate to the delete confirmation page. Confirm the "expired" message renders and no delete button is shown.
+
+---
+
+## Implementation Notes for the Solution Architect
+
+These are testing constraints the implementation must accommodate.
+
+**Analytics intercept pattern (CMT-E2E-18 through CMT-E2E-20)**: Vercel Analytics sends beacons to `va.vercel-insights.com`. In local dev (`localhost:3000`), the Analytics package is typically a no-op unless `NEXT_PUBLIC_VERCEL_ENV` is set. Before writing CMT-E2E-18 through CMT-E2E-20, verify whether `track()` calls fire network requests in dev mode. If not, the tests must either: (a) set `NEXT_PUBLIC_VERCEL_ENV=production` in the Playwright environment, or (b) expose a `window.__lastTrackedEvent` test hook that `track()` populates in addition to (not instead of) the real call. Option (b) avoids the dependency on external network access in CI and is the more reliable approach.
+
+**Token page test seam (CMT-E2E-22 through CMT-E2E-25)**: The `getServerSideProps` in `pages/owner/comments/delete.js` calls `verifyDeleteToken` and `getById`. In test environments, `getById` will attempt a real Neon connection. Add a check: `if (process.env.PLAYWRIGHT_TEST_COMMENT_PREVIEW)` then skip the DB call and return the env-var-parsed JSON as `commentPreview`. Set this env var in the Playwright config for the token page tests.
+
+**axe-core installation**: Add `@axe-core/playwright` to `devDependencies`. The import pattern is:
+```js
+import AxeBuilder from "@axe-core/playwright";
+// …
+const results = await new AxeBuilder({ page }).analyze();
+const violations = results.violations.filter(
+  v => v.impact === "critical" || v.impact === "serious"
+);
+expect(violations).toEqual([]);
+```
+
+**`vitest.config.js` path aliases**: Confirm that `@/` resolves to the repo root in the Vitest config. The integration tests import `@/pages/api/…` and `@/lib/…`. If this breaks after a Next.js or Vitest upgrade, the fix is to add `resolve.alias: { "@": new URL(".", import.meta.url).pathname }` to `vitest.config.js`.

--- a/lib/analytics.js
+++ b/lib/analytics.js
@@ -1,0 +1,26 @@
+/**
+ * Thin wrapper around Vercel Analytics `track()` that ALSO records the
+ * last fired event on `window.__lastTrackedEvent` so Playwright tests can
+ * assert which event fired without depending on the analytics beacon
+ * actually leaving the browser (which it doesn't in dev mode).
+ *
+ * Production behaviour is identical to calling `track()` directly — the
+ * window assignment is a no-op nobody reads in production. Phase 6 QA plan
+ * documents this seam under "Implementation Notes for the Solution
+ * Architect" → "Analytics intercept pattern".
+ *
+ * @param {string} name — Custom event name (e.g. "comment_submitted").
+ * @param {Record<string, unknown>} [properties] — Optional event properties.
+ */
+import { track } from "@vercel/analytics";
+
+export function trackEvent(name, properties) {
+  track(name, properties);
+  if (typeof window !== "undefined") {
+    window.__lastTrackedEvent = {
+      name,
+      properties: properties ?? null,
+      at: Date.now(),
+    };
+  }
+}

--- a/lib/ipHash.ts
+++ b/lib/ipHash.ts
@@ -87,6 +87,13 @@ export function hashIp(ip: string): string {
  *
  * Returns a RAW IP. The caller is responsible for hashing it before it
  * touches Redis, Postgres, or a log line.
+ *
+ * CURRENT IMPLEMENTATION NOTE: This module does NOT persist IP data (raw
+ * or hashed) to Postgres. IPs are used only transiently as Upstash Redis
+ * keys (always hashed via `hashIp`). This is a deliberate privacy choice
+ * — documented in docs/comments-phase-6-plan.md §6B. If a future phase
+ * adds IP data to the DB for abuse investigation, it MUST use `hashIp`
+ * and MUST update this comment.
  */
 export function extractClientIp(req: NextApiRequest): string {
   const xff = req.headers["x-forwarded-for"];

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.10.0",
         "@tailwindcss/typography": "^0.5.19",
         "@types/node": "^24.10.1",
         "@types/react": "^19.0.0",
@@ -52,6 +53,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.2.tgz",
+      "integrity": "sha512-iP6hfNl9G0j/SEUSo8M7D80RbcDo9KRAAfDP4IT5OHB+Wm6zUHIrm8Y51BKI+Oyqduvipf9u1hcRy57zCBKzWQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.3"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -4737,9 +4751,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
-      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.10.0",
     "@tailwindcss/typography": "^0.5.19",
     "@types/node": "^24.10.1",
     "@types/react": "^19.0.0",

--- a/pages/api/comments/index.ts
+++ b/pages/api/comments/index.ts
@@ -77,6 +77,23 @@ async function handleGet(
     sendError(res, 400, "VALIDATION", "postId query parameter is required.");
     return;
   }
+
+  // Test seam: when running the Playwright suite against `npm run start`,
+  // `DATABASE_URL` is not set on CI and we must not hit a real Neon
+  // database. Tests that care about the comment list stub `/api/comments`
+  // explicitly via `page.route()`, which intercepts before this handler
+  // runs, so the seam only affects unrelated tests (blog / theme specs)
+  // that navigate through post pages and would otherwise log a spurious
+  // `DatabaseConfigError` stack trace on every page load.
+  //
+  // Gated on a non-public env var so production builds can never enable
+  // it. Mirrors the `PLAYWRIGHT_TEST_COMMENT_PREVIEW` seam in
+  // `pages/owner/comments/delete.js`.
+  if (process.env.PLAYWRIGHT_TEST_COMMENT_STUB === "1") {
+    res.status(200).json({ comments: [], total: 0 });
+    return;
+  }
+
   const rawLimit = parsePositiveInt(req.query.limit, DEFAULT_LIMIT);
   const limit = Math.min(Math.max(rawLimit, 1), MAX_LIMIT);
   const offset = parsePositiveInt(req.query.offset, DEFAULT_OFFSET);

--- a/pages/owner/comments/delete.js
+++ b/pages/owner/comments/delete.js
@@ -178,6 +178,7 @@ export default function OwnerDeletePage({ tokenStatus, token, commentPreview }) 
       {uiState === "success" && (
         <p
           role="status"
+          data-testid="delete-success"
           className="text-green-700 dark:text-green-400 text-base py-4"
         >
           Comment deleted. You can close this tab.
@@ -187,7 +188,10 @@ export default function OwnerDeletePage({ tokenStatus, token, commentPreview }) 
       {/* Valid token, comment present, pre-delete UI */}
       {tokenStatus === "VALID" && commentPreview !== null && uiState !== "success" && (
         <section aria-label="Delete comment confirmation">
-          <div className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg p-4 mb-4">
+          <div
+            data-testid="delete-preview"
+            className="bg-white dark:bg-slate-800 border border-gray-200 dark:border-slate-700 rounded-lg p-4 mb-4"
+          >
             <p className="text-sm text-gray-500 dark:text-slate-400 mb-1">
               On post: <span className="font-mono">{commentPreview.postId}</span>
             </p>
@@ -217,6 +221,7 @@ export default function OwnerDeletePage({ tokenStatus, token, commentPreview }) 
 
           <button
             type="button"
+            data-testid="confirm-token-delete"
             onClick={handleDelete}
             disabled={uiState === "submitting"}
             className="bg-red-600 dark:bg-red-500 text-white font-medium px-5 py-2.5 rounded-md hover:bg-red-700 dark:hover:bg-red-400 disabled:opacity-50 disabled:cursor-not-allowed focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600 dark:focus-visible:outline-red-400"

--- a/pages/owner/comments/delete.js
+++ b/pages/owner/comments/delete.js
@@ -36,6 +36,37 @@ export async function getServerSideProps(context) {
   const rawToken = context.query?.token;
   const token = Array.isArray(rawToken) ? rawToken[0] : rawToken;
 
+  // Test seam: when running under Playwright, skip the real Neon call and
+  // return a deterministic preview. Honours verifyDeleteToken so the four
+  // token states (VALID / EXPIRED / BAD_SIGNATURE / MALFORMED) still render
+  // the right messages. Gated on a non-public env var so this can never be
+  // enabled in production builds. Documented in comments-phase-6-qa-plan.md §3.
+  if (process.env.PLAYWRIGHT_TEST_COMMENT_PREVIEW === "1") {
+    if (typeof token !== "string" || token.length === 0) {
+      return {
+        props: { tokenStatus: "MALFORMED", token: "", commentPreview: null },
+      };
+    }
+    const r = verifyDeleteToken(token);
+    if (!r.ok) {
+      return {
+        props: { tokenStatus: r.reason, token, commentPreview: null },
+      };
+    }
+    return {
+      props: {
+        tokenStatus: "VALID",
+        token,
+        commentPreview: {
+          postId: "2025-01-30-scrum",
+          author: "Test Commenter",
+          body: "Test body for Playwright assertion.",
+          createdAt: new Date("2026-04-22T12:00:00Z").toISOString(),
+        },
+      },
+    };
+  }
+
   if (typeof token !== "string" || token.length === 0) {
     return {
       props: {

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -74,10 +74,11 @@ module.exports = defineConfig({
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'npm run start',
+    url: 'http://127.0.0.1:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
 });
 

--- a/tests/comments.spec.js
+++ b/tests/comments.spec.js
@@ -546,8 +546,21 @@ test("CMT-E2E-15: honeypot input is not visible, not tabbable, autoComplete=off"
   // Attached to DOM
   await expect(honeypot).toBeAttached();
 
-  // Not visible to real users (wrapped in sr-only)
-  expect(await honeypot.isVisible()).toBe(false);
+  // Not visible to real users. Playwright's `isVisible()` treats
+  // Tailwind's `sr-only` class (clip-path + 1×1) as visible, so instead
+  // assert the element is inside a wrapper with aria-hidden="true" OR the
+  // sr-only utility class — either is sufficient to hide from sighted
+  // users and (for aria-hidden) from assistive tech.
+  const effectivelyHidden = await honeypot.evaluate((el) => {
+    let cur = el.parentElement;
+    while (cur) {
+      if (cur.getAttribute && cur.getAttribute("aria-hidden") === "true") return true;
+      if (cur.classList && cur.classList.contains("sr-only")) return true;
+      cur = cur.parentElement;
+    }
+    return false;
+  });
+  expect(effectivelyHidden).toBe(true);
 
   // tabIndex = -1 removes it from the tab order
   await expect(honeypot).toHaveAttribute("tabindex", "-1");
@@ -912,7 +925,9 @@ test("CMT-E2E-23: token page — expired token renders expired alert, no delete 
     `${BASE_URL}/owner/comments/delete?token=${encodeURIComponent(token)}`,
   );
 
-  const alert = page.locator('[role="alert"]');
+  // Exclude Next's built-in `#__next-route-announcer__` which also carries
+  // role="alert" and would trip strict mode.
+  const alert = page.locator('[role="alert"]:not(#__next-route-announcer__)');
   await expect(alert).toBeVisible();
   await expect(alert).toContainText("expired");
 
@@ -930,7 +945,9 @@ test("CMT-E2E-24: token page — malformed token renders generic alert", async (
     `${BASE_URL}/owner/comments/delete?token=not-a-valid-token`,
   );
 
-  const alert = page.locator('[role="alert"]');
+  // Exclude Next.js's built-in route announcer (`#__next-route-announcer__`)
+  // which also has role="alert" and would otherwise trip strict mode.
+  const alert = page.locator('[role="alert"]:not(#__next-route-announcer__)');
   await expect(alert).toBeVisible();
   // Malformed copy is distinct from expired copy
   await expect(alert).not.toContainText("expired");
@@ -962,7 +979,9 @@ test("CMT-E2E-25: token page — tampered signature renders BAD_SIGNATURE alert"
     `${BASE_URL}/owner/comments/delete?token=${encodeURIComponent(tamperedToken)}`,
   );
 
-  const alert = page.locator('[role="alert"]');
+  // Exclude Next's built-in `#__next-route-announcer__` which also carries
+  // role="alert" and would trip strict mode.
+  const alert = page.locator('[role="alert"]:not(#__next-route-announcer__)');
   await expect(alert).toBeVisible();
   await expect(alert).toContainText("not valid");
   await expect(page.locator('[data-testid="confirm-token-delete"]')).toHaveCount(0);
@@ -1000,11 +1019,13 @@ test("CMT-E2E-26: admin login — wrong password → alert; correct password →
   // The password field should be focused on mount
   await expect(page.locator("#admin-password")).toBeFocused();
 
-  // Wrong password attempt
+  // Wrong password attempt. Exclude Next's built-in
+  // `#__next-route-announcer__` which also carries role="alert".
+  const alert = page.locator('[role="alert"]:not(#__next-route-announcer__)');
   await page.fill("#admin-password", "wrong-password");
   await page.click('button[type="submit"]');
-  await expect(page.locator('[role="alert"]')).toBeVisible();
-  await expect(page.locator('[role="alert"]')).toContainText("Invalid password");
+  await expect(alert).toBeVisible();
+  await expect(alert).toContainText("Invalid password");
 
   // Correct password — response triggers window.location.reload() so we
   // pre-seed the cookie via the browser context so the reloaded page sees
@@ -1228,9 +1249,10 @@ test("CMT-E2E-31: delete confirm — Cancel closes the confirm row and returns f
   await expect(confirmBtn).toHaveCount(0);
   await expect(deleteBtn).toBeVisible();
 
-  // Focus is returned to the original delete button
-  const activeTestId = await page.evaluate(
-    () => document.activeElement?.getAttribute?.("data-testid") ?? null,
-  );
-  expect(activeTestId).toBe("delete-comment");
+  // Focus is returned to the original delete button. `toBeFocused()` polls
+  // until the assertion passes (or the default timeout elapses), which
+  // correctly awaits the React effect that re-focuses after re-render. A
+  // one-shot `page.evaluate(() => document.activeElement)` would race the
+  // commit and report `<body>` instead.
+  await expect(deleteBtn).toBeFocused();
 });

--- a/tests/comments.spec.js
+++ b/tests/comments.spec.js
@@ -10,10 +10,47 @@
  *   - POST_SLUG must be a post that exists in the static build.
  */
 import { test, expect } from "@playwright/test";
+import crypto from "node:crypto";
 
 const BASE_URL = "http://localhost:3000";
 const POST_SLUG = "2025-01-30-scrum";
 const POST_URL = `${BASE_URL}/posts/${POST_SLUG}`;
+
+// ---------------------------------------------------------------------------
+// Delete-token helpers (mirror lib/deleteToken.ts exactly — we replicate the
+// HMAC rather than importing the .ts module so this .js spec stays portable).
+// Used by CMT-E2E-22 through CMT-E2E-25.
+// ---------------------------------------------------------------------------
+
+const TOKEN_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+function toB64Url(input) {
+  const buf = typeof input === "string" ? Buffer.from(input, "utf8") : input;
+  return buf.toString("base64url");
+}
+
+/** Produce a signed token identical in format to lib/deleteToken.ts. */
+function signToken(commentId, expiresAtMs, secret) {
+  const sig = crypto
+    .createHmac("sha256", secret)
+    .update(`${commentId}.${expiresAtMs}`)
+    .digest();
+  return [toB64Url(commentId), toB64Url(String(expiresAtMs)), toB64Url(sig)].join(".");
+}
+
+/** Require the DELETE_TOKEN_SECRET env var — tests that need a token skip
+ *  without it so local runs without the secret don't fail opaquely. */
+function getTokenSecretOrSkip(testInfo) {
+  const secret = process.env.DELETE_TOKEN_SECRET;
+  if (!secret || secret.length < 32) {
+    testInfo.skip(
+      true,
+      "DELETE_TOKEN_SECRET not set (>=32 chars) — skipping token-page test.",
+    );
+    return "";
+  }
+  return secret;
+}
 
 // ---------------------------------------------------------------------------
 // Stub data helpers
@@ -430,4 +467,770 @@ test("CMT-E2E-12: server 500 on GET → role='alert' error message shown", async
     hasText: "Comments could not be loaded",
   });
   await expect(errorAlert).toBeVisible({ timeout: 5000 });
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-13: Character counter visible update on every keystroke + red at <20
+// ---------------------------------------------------------------------------
+test("CMT-E2E-13: visible character counter updates as body grows, turns red under 20", async ({
+  page,
+}) => {
+  await stubComments(page, { comments: [] });
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  const body = page.locator('[data-testid="comment-form"] textarea[name="body"]');
+  const counter = page.locator("#body-char-count");
+
+  // Empty — counter shows 1000 remaining (MAX_BODY)
+  await expect(counter).toHaveText("1000 remaining");
+
+  // Fill to 900 chars → "100 remaining"
+  await body.fill("a".repeat(900));
+  await expect(counter).toHaveText("100 remaining");
+
+  // Fill to 950 → "50 remaining"
+  await body.fill("a".repeat(950));
+  await expect(counter).toHaveText("50 remaining");
+
+  // Fill to 985 → "15 remaining" (under 20 threshold → red class)
+  await body.fill("a".repeat(985));
+  await expect(counter).toHaveText("15 remaining");
+  await expect(counter).toHaveClass(/text-red-600/);
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-14: Polite live region announces at thresholds (100, 50, 20, 0)
+// ---------------------------------------------------------------------------
+test("CMT-E2E-14: aria-live polite region announces at character thresholds", async ({
+  page,
+}) => {
+  await stubComments(page, { comments: [] });
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  const body = page.locator('[data-testid="comment-form"] textarea[name="body"]');
+  // The polite live region is the sr-only paragraph with aria-live="polite"
+  // inside the form. Scope to the form to avoid matching other live regions.
+  const liveRegion = page.locator(
+    '[data-testid="comment-form"] [aria-live="polite"].sr-only',
+  );
+
+  // The live region is initially empty (announcedRemaining === null)
+  await expect(liveRegion).toHaveText("");
+
+  // Threshold: 100 remaining (exactly 900 chars) — fire change event via fill
+  await body.fill("a".repeat(900));
+  await expect(liveRegion).toHaveText("100 characters remaining");
+
+  // Threshold: 50 remaining (exactly 950 chars)
+  await body.fill("a".repeat(950));
+  await expect(liveRegion).toHaveText("50 characters remaining");
+
+  // Visible counter updates as well
+  await expect(page.locator("#body-char-count")).toHaveText("50 remaining");
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-15: Honeypot invisible and removed from tab order
+// ---------------------------------------------------------------------------
+test("CMT-E2E-15: honeypot input is not visible, not tabbable, autoComplete=off", async ({
+  page,
+}) => {
+  await stubComments(page, { comments: [] });
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  const honeypot = page.locator('[data-testid="comment-form"] input[name="url"]');
+
+  // Attached to DOM
+  await expect(honeypot).toBeAttached();
+
+  // Not visible to real users (wrapped in sr-only)
+  expect(await honeypot.isVisible()).toBe(false);
+
+  // tabIndex = -1 removes it from the tab order
+  await expect(honeypot).toHaveAttribute("tabindex", "-1");
+
+  // autoComplete off so browsers don't fill it in
+  await expect(honeypot).toHaveAttribute("autocomplete", "off");
+
+  // Fill the real fields and tab through — focus must never land on the
+  // honeypot. We press Tab up to 10 times and assert document.activeElement
+  // never becomes the honeypot element.
+  const author = page.locator('[data-testid="comment-form"] input[name="author"]');
+  await author.focus();
+  for (let i = 0; i < 10; i++) {
+    const focusedName = await page.evaluate(
+      () => document.activeElement?.getAttribute?.("name") ?? "",
+    );
+    expect(focusedName).not.toBe("url");
+    await page.keyboard.press("Tab");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-16: Honeypot filled → server 200 with sentinel comment, UI swallows it
+// ---------------------------------------------------------------------------
+// The real server (pages/api/comments/index.ts honeypot branch) returns a
+// fake comment with the all-zeros UUID 00000000-0000-0000-0000-000000000000
+// to fool simple bots that just check the response code. The client UI
+// (CommentsSection.handleSuccess) recognises this sentinel and silently
+// discards the fake comment so it never renders. This test stubs the real
+// server response shape and asserts the sentinel is correctly swallowed.
+test("CMT-E2E-16: honeypot filled → POST returns 200 with sentinel comment, list stays empty", async ({
+  page,
+}) => {
+  await page.route(`**/api/comments?**`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ comments: [], total: 0 }),
+    });
+  });
+  // Honeypot-filled POST: server returns 200 with the fake all-zeros UUID
+  // comment, mirroring pages/api/comments/index.ts behaviour exactly.
+  await page.route(`**/api/comments`, (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          comment: {
+            id: "00000000-0000-0000-0000-000000000000",
+            postId: POST_SLUG,
+            author: "Alice",
+            body: "Honeypot body.",
+            createdAt: "2026-04-22T12:00:00.000Z",
+            status: "approved",
+          },
+        }),
+      });
+    }
+    route.continue();
+  });
+
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  await page.fill('[data-testid="comment-form"] input[name="author"]', "Alice");
+  await page.fill(
+    '[data-testid="comment-form"] textarea[name="body"]',
+    "Honeypot body.",
+  );
+  // Directly set the hidden honeypot input — bots would fill this
+  await page.evaluate(() => {
+    const el = document.querySelector(
+      '[data-testid="comment-form"] input[name="url"]',
+    );
+    if (el) {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        "value",
+      ).set;
+      setter.call(el, "http://spam.example.com");
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+  });
+
+  await page.click('[data-testid="submit-comment"]');
+
+  // No comment-item should be present
+  await expect(page.locator('[data-testid="comment-item"]')).toHaveCount(0);
+  // No server-error role=alert
+  await expect(
+    page.locator('[role="alert"]', { hasText: "Something went wrong" }),
+  ).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-17: Rate-limit 429 → countdown, disabled submit, re-enables after
+// ---------------------------------------------------------------------------
+test("CMT-E2E-17: rate-limit 429 → alert shown, submit disabled, re-enables after countdown", async ({
+  page,
+}) => {
+  await page.route(`**/api/comments?**`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ comments: [], total: 0 }),
+    });
+  });
+  await page.route(`**/api/comments`, (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({
+        status: 429,
+        contentType: "application/json",
+        headers: { "Retry-After": "3" },
+        body: JSON.stringify({
+          error: { code: "RATE_LIMIT", message: "Too many submissions." },
+        }),
+      });
+    }
+    route.continue();
+  });
+
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  await page.fill('[data-testid="comment-form"] input[name="author"]', "Alice");
+  await page.fill(
+    '[data-testid="comment-form"] textarea[name="body"]',
+    "Body 1.",
+  );
+  await page.click('[data-testid="submit-comment"]');
+
+  // Rate-limit alert shown
+  const alert = page.locator('[role="alert"]', { hasText: "Too many submissions" });
+  await expect(alert).toBeVisible();
+
+  // Countdown reads "(Ns)" inside the alert; submit disabled
+  const submit = page.locator('[data-testid="submit-comment"]');
+  await expect(submit).toBeDisabled();
+
+  // Wait past the 3s countdown — form should re-enable and alert clear
+  await page.waitForTimeout(4000);
+  await expect(submit).toBeEnabled();
+  await expect(alert).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-18: comment_submitted analytics event fires on success
+// ---------------------------------------------------------------------------
+test("CMT-E2E-18: comment_submitted analytics event fires on successful submit", async ({
+  page,
+}) => {
+  await stubComments(page, {
+    comments: [],
+    newComment: {
+      id: "new-1",
+      postId: POST_SLUG,
+      author: "Alice",
+      body: "Hello world.",
+      createdAt: "2026-04-22T12:00:00.000Z",
+      status: "approved",
+    },
+  });
+
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  await page.fill('[data-testid="comment-form"] input[name="author"]', "Alice");
+  await page.fill(
+    '[data-testid="comment-form"] textarea[name="body"]',
+    "Hello world.",
+  );
+  await page.click('[data-testid="submit-comment"]');
+
+  // New comment rendered → trackEvent has fired synchronously before this
+  await expect(page.locator('[data-testid="comment-item"]').first()).toBeVisible();
+
+  const last = await page.evaluate(() => window.__lastTrackedEvent);
+  expect(last?.name).toBe("comment_submitted");
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-19: comment_load_more analytics event fires on Show more click
+// ---------------------------------------------------------------------------
+test("CMT-E2E-19: comment_load_more analytics event fires on Show more click", async ({
+  page,
+}) => {
+  const sevenComments = Array.from({ length: 7 }, (_, i) =>
+    makeComment({
+      id: `comment-${i}`,
+      author: `User ${i + 1}`,
+      body: `Comment ${i + 1}`,
+    }),
+  );
+  await stubComments(page, { comments: sevenComments });
+
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  const showMore = page.locator('[data-testid="show-more"]');
+  await expect(showMore).toBeVisible();
+
+  // Reset any ambient event from earlier interactions
+  await page.evaluate(() => {
+    window.__lastTrackedEvent = null;
+  });
+
+  await showMore.click();
+  await expect(page.locator('[data-testid="comment-item"]')).toHaveCount(7);
+
+  const last = await page.evaluate(() => window.__lastTrackedEvent);
+  expect(last?.name).toBe("comment_load_more");
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-20: comment_deleted analytics event fires after owner deletes
+// ---------------------------------------------------------------------------
+test("CMT-E2E-20: comment_deleted analytics event fires after owner confirms delete", async ({
+  page,
+}) => {
+  const comment = makeComment({ id: "delete-me", author: "Bob", body: "To be deleted" });
+  await stubComments(page, { comments: [comment] });
+
+  await page.route(`**/api/comments/delete-me`, (route) => {
+    if (route.request().method() === "DELETE") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, id: "delete-me" }),
+      });
+    }
+    route.continue();
+  });
+
+  await page.addInitScript(() => {
+    document.cookie = "owner_ui=1; path=/";
+  });
+
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  // Reset any event from mount
+  await page.evaluate(() => {
+    window.__lastTrackedEvent = null;
+  });
+
+  await page.locator('[data-testid="delete-comment"]').first().click();
+  await page.locator('[data-testid="confirm-delete"]').first().click();
+
+  await expect(page.locator('[data-testid="comment-item"]')).toHaveCount(0);
+
+  const last = await page.evaluate(() => window.__lastTrackedEvent);
+  expect(last?.name).toBe("comment_deleted");
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-21: Error boundary — render error does not break the post page
+// ---------------------------------------------------------------------------
+// We seed a comment whose `body` is an OBJECT (not a string). React will
+// throw "Objects are not valid as a React child" during render inside
+// CommentItem, which the CommentErrorBoundary around CommentsSectionInner
+// catches. The rest of the page (including the post <h1>) must still render.
+test("CMT-E2E-21: error boundary catches render error, post page still renders", async ({
+  page,
+}) => {
+  const badComment = {
+    id: "bad-1",
+    postId: POST_SLUG,
+    author: "Alice",
+    // Non-string body triggers render error in CommentItem's <p>{body}</p>
+    body: { oops: "not a string" },
+    createdAt: "2026-04-22T12:00:00.000Z",
+    status: "approved",
+  };
+
+  await page.route(`**/api/comments?**`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ comments: [badComment], total: 1 }),
+    });
+  });
+  await page.route(`**/api/comments`, (route) => route.continue());
+
+  await page.goto(POST_URL);
+
+  // Error boundary fallback visible with the sentinel testid
+  await expect(page.locator('[data-testid="comments-error"]')).toBeVisible({
+    timeout: 10000,
+  });
+
+  // The post's <h1> is still rendered (outside the comments section)
+  await expect(page.locator("h1").first()).toBeVisible();
+
+  // The form should NOT be present — the whole section was replaced by the boundary
+  await expect(page.locator('[data-testid="comment-form"]')).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-22: Token page — valid token shows preview, delete succeeds
+// ---------------------------------------------------------------------------
+// Requires: PLAYWRIGHT_TEST_COMMENT_PREVIEW=1 AND DELETE_TOKEN_SECRET set on
+// the Next.js server process. Without the former, getServerSideProps will
+// hit real Neon and these assertions will be flaky. The seam is documented
+// in pages/owner/comments/delete.js and comments-phase-6-qa-plan.md §3.
+test("CMT-E2E-22: token page — valid token shows preview; confirm delete shows success", async ({
+  page,
+}, testInfo) => {
+  const secret = getTokenSecretOrSkip(testInfo);
+  if (!secret) return;
+
+  const commentId = "aaaaaaaa-0000-0000-0000-000000000022";
+  const token = signToken(commentId, Date.now() + TOKEN_TTL_MS, secret);
+
+  // Stub the POST endpoint to succeed
+  await page.route(`**/api/owner/delete-by-token`, (route) => {
+    if (route.request().method() === "POST") {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+    }
+    route.continue();
+  });
+
+  await page.goto(
+    `${BASE_URL}/owner/comments/delete?token=${encodeURIComponent(token)}`,
+  );
+
+  await expect(page.getByRole("heading", { name: "Delete comment" })).toBeVisible();
+  const preview = page.locator('[data-testid="delete-preview"]');
+  await expect(preview).toBeVisible();
+  // The seam's preview uses author "Test Commenter"
+  await expect(preview).toContainText("Test Commenter");
+
+  const confirm = page.locator('[data-testid="confirm-token-delete"]');
+  await expect(confirm).toBeEnabled();
+  await confirm.click();
+
+  await expect(page.locator('[data-testid="delete-success"]')).toBeVisible();
+  await expect(page.locator('[data-testid="delete-success"]')).toContainText(
+    "Comment deleted. You can close this tab.",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-23: Token page — expired token shows "expired" message
+// ---------------------------------------------------------------------------
+test("CMT-E2E-23: token page — expired token renders expired alert, no delete button", async ({
+  page,
+}, testInfo) => {
+  const secret = getTokenSecretOrSkip(testInfo);
+  if (!secret) return;
+
+  const commentId = "aaaaaaaa-0000-0000-0000-000000000023";
+  // Timestamp one hour in the past — signature is valid, token is expired
+  const expiredAt = Date.now() - 60 * 60 * 1000;
+  const token = signToken(commentId, expiredAt, secret);
+
+  await page.goto(
+    `${BASE_URL}/owner/comments/delete?token=${encodeURIComponent(token)}`,
+  );
+
+  const alert = page.locator('[role="alert"]');
+  await expect(alert).toBeVisible();
+  await expect(alert).toContainText("expired");
+
+  await expect(page.locator('[data-testid="delete-preview"]')).toHaveCount(0);
+  await expect(page.locator('[data-testid="confirm-token-delete"]')).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-24: Token page — malformed token shows generic error (not "expired")
+// ---------------------------------------------------------------------------
+test("CMT-E2E-24: token page — malformed token renders generic alert", async ({
+  page,
+}) => {
+  await page.goto(
+    `${BASE_URL}/owner/comments/delete?token=not-a-valid-token`,
+  );
+
+  const alert = page.locator('[role="alert"]');
+  await expect(alert).toBeVisible();
+  // Malformed copy is distinct from expired copy
+  await expect(alert).not.toContainText("expired");
+  await expect(alert).toContainText("malformed");
+
+  await expect(page.locator('[data-testid="confirm-token-delete"]')).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-25: Token page — bad signature shows "not valid"
+// ---------------------------------------------------------------------------
+test("CMT-E2E-25: token page — tampered signature renders BAD_SIGNATURE alert", async ({
+  page,
+}, testInfo) => {
+  const secret = getTokenSecretOrSkip(testInfo);
+  if (!secret) return;
+
+  const commentId = "aaaaaaaa-0000-0000-0000-000000000025";
+  const token = signToken(commentId, Date.now() + TOKEN_TTL_MS, secret);
+
+  // Tamper: flip a byte in the signature segment
+  const parts = token.split(".");
+  const sigBuf = Buffer.from(parts[2], "base64url");
+  sigBuf[0] ^= 0xff; // flip all bits of the first byte
+  parts[2] = sigBuf.toString("base64url");
+  const tamperedToken = parts.join(".");
+
+  await page.goto(
+    `${BASE_URL}/owner/comments/delete?token=${encodeURIComponent(tamperedToken)}`,
+  );
+
+  const alert = page.locator('[role="alert"]');
+  await expect(alert).toBeVisible();
+  await expect(alert).toContainText("not valid");
+  await expect(page.locator('[data-testid="confirm-token-delete"]')).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-26: Admin login — wrong password shows error, correct sets cookie
+// ---------------------------------------------------------------------------
+test("CMT-E2E-26: admin login — wrong password → alert; correct password → logged-in state", async ({
+  page,
+  context,
+}) => {
+  // Stateful stub: first POST returns 401, subsequent returns 200 + sets cookie
+  let attempts = 0;
+  await page.route(`**/api/auth/login`, async (route) => {
+    if (route.request().method() !== "POST") return route.continue();
+    attempts++;
+    if (attempts === 1) {
+      return route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: { code: "UNAUTHORIZED", message: "Wrong password" } }),
+      });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      headers: { "Set-Cookie": "owner_ui=1; Path=/; SameSite=Lax" },
+      body: JSON.stringify({ ok: true }),
+    });
+  });
+
+  await page.goto(`${BASE_URL}/admin`);
+
+  // The password field should be focused on mount
+  await expect(page.locator("#admin-password")).toBeFocused();
+
+  // Wrong password attempt
+  await page.fill("#admin-password", "wrong-password");
+  await page.click('button[type="submit"]');
+  await expect(page.locator('[role="alert"]')).toBeVisible();
+  await expect(page.locator('[role="alert"]')).toContainText("Invalid password");
+
+  // Correct password — response triggers window.location.reload() so we
+  // pre-seed the cookie via the browser context so the reloaded page sees
+  // the logged-in state. (The Set-Cookie header from route.fulfill is not
+  // reliably applied by Playwright's request interception in all versions.)
+  await context.addCookies([
+    {
+      name: "owner_ui",
+      value: "1",
+      url: BASE_URL,
+      sameSite: "Lax",
+    },
+  ]);
+
+  await page.fill("#admin-password", "correct-password");
+  await page.click('button[type="submit"]');
+
+  // After the reload the page shows the logged-in section with a Sign out button
+  await expect(page.getByRole("button", { name: "Sign out" })).toBeVisible();
+  await expect(page.locator("#admin-password")).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-27: Accessibility audit — post page with comments (axe-core)
+// ---------------------------------------------------------------------------
+// NOTE: requires @axe-core/playwright in devDependencies. If the package is
+// missing at run time, the dynamic import throws and the test fails loudly —
+// that's the signal that the parallel CI agent's dep hasn't landed yet.
+test("CMT-E2E-27: axe-core — post page with comments has no critical/serious violations", async ({
+  page,
+}) => {
+  const comments = [
+    makeComment({ id: "c1", author: "Alice", body: "Short comment." }),
+    makeComment({
+      id: "c2",
+      author: "Bob",
+      body: "A longer comment body to exercise the card layout with realistic content.",
+    }),
+    makeComment({ id: "c3", author: "Carol", body: "Third." }),
+  ];
+  await stubComments(page, { comments });
+
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  const { default: AxeBuilder } = await import("@axe-core/playwright");
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21aa"])
+    .analyze();
+  const blockers = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blockers, JSON.stringify(blockers, null, 2)).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-28: Accessibility audit — delete confirm row open (axe-core)
+// ---------------------------------------------------------------------------
+test("CMT-E2E-28: axe-core — delete confirm row has no critical/serious violations", async ({
+  page,
+}) => {
+  const comment = makeComment({ id: "confirm-1", author: "Alice", body: "Hi." });
+  await stubComments(page, { comments: [comment] });
+
+  await page.addInitScript(() => {
+    document.cookie = "owner_ui=1; path=/";
+  });
+
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  await page.locator('[data-testid="delete-comment"]').first().click();
+  await expect(page.locator('[data-testid="confirm-delete"]').first()).toBeVisible();
+
+  const { default: AxeBuilder } = await import("@axe-core/playwright");
+  const results = await new AxeBuilder({ page })
+    .withTags(["wcag2a", "wcag2aa", "wcag21aa"])
+    .analyze();
+  const blockers = results.violations.filter(
+    (v) => v.impact === "critical" || v.impact === "serious",
+  );
+  expect(blockers, JSON.stringify(blockers, null, 2)).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-29: Privacy notice text present (Wave 1 copy)
+// ---------------------------------------------------------------------------
+test("CMT-E2E-29: privacy notice is visible above the form with Wave 1 copy", async ({
+  page,
+}) => {
+  await stubComments(page, { comments: [] });
+  await page.goto(POST_URL);
+
+  const form = page.locator('[data-testid="comment-form"]');
+  await expect(form).toBeVisible();
+
+  // Wave 1 copy — matched against the opening clause to keep the assertion
+  // resilient to trailing whitespace differences between dev and prod.
+  await expect(form).toContainText("Comments are public and permanent");
+  await expect(form).toContainText(
+    "No email address or IP address is stored",
+  );
+
+  // The privacy paragraph is NOT sr-only — assert visibility
+  const privacy = form
+    .locator("p", { hasText: "Comments are public and permanent" })
+    .first();
+  await expect(privacy).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-30: 5 rapid POSTs succeed, 6th returns 429 (stateful stub)
+// ---------------------------------------------------------------------------
+test("CMT-E2E-30: stateful rate-limit — 5 succeed, 6th submission blocked by 429", async ({
+  page,
+}) => {
+  await page.route(`**/api/comments?**`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ comments: [], total: 0 }),
+    });
+  });
+
+  let postCount = 0;
+  await page.route(`**/api/comments`, (route) => {
+    if (route.request().method() !== "POST") return route.continue();
+    postCount++;
+    if (postCount <= 5) {
+      return route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify({
+          comment: {
+            id: `ok-${postCount}`,
+            postId: POST_SLUG,
+            author: `User ${postCount}`,
+            body: `Body ${postCount}`,
+            createdAt: new Date().toISOString(),
+            status: "approved",
+          },
+        }),
+      });
+    }
+    return route.fulfill({
+      status: 429,
+      contentType: "application/json",
+      headers: { "Retry-After": "10" },
+      body: JSON.stringify({
+        error: { code: "RATE_LIMIT", message: "Too many submissions." },
+      }),
+    });
+  });
+
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  const authorInput = page.locator(
+    '[data-testid="comment-form"] input[name="author"]',
+  );
+  const bodyInput = page.locator(
+    '[data-testid="comment-form"] textarea[name="body"]',
+  );
+  const submit = page.locator('[data-testid="submit-comment"]');
+
+  // Submit 5 successful comments. The form auto-clears 3 seconds after
+  // success, but we don't need to wait — we manually re-fill each time.
+  for (let i = 1; i <= 5; i++) {
+    await authorInput.fill(`User ${i}`);
+    await bodyInput.fill(`Body number ${i}`);
+    await submit.click();
+    // Wait for the new comment to appear before submitting the next one
+    await expect(page.locator('[data-testid="comment-item"]')).toHaveCount(i);
+  }
+
+  // 6th attempt → 429
+  await authorInput.fill("User 6");
+  await bodyInput.fill("Body number 6");
+  await submit.click();
+
+  await expect(
+    page.locator('[role="alert"]', { hasText: "Too many submissions" }),
+  ).toBeVisible();
+  await expect(submit).toBeDisabled();
+  // Still only 5 items in the list
+  await expect(page.locator('[data-testid="comment-item"]')).toHaveCount(5);
+});
+
+// ---------------------------------------------------------------------------
+// CMT-E2E-31: Delete confirm — Cancel restores focus to the delete button
+// ---------------------------------------------------------------------------
+test("CMT-E2E-31: delete confirm — Cancel closes the confirm row and returns focus", async ({
+  page,
+}) => {
+  const comment = makeComment({ id: "focus-1", author: "Alice", body: "Hi." });
+  await stubComments(page, { comments: [comment] });
+
+  await page.addInitScript(() => {
+    document.cookie = "owner_ui=1; path=/";
+  });
+
+  await page.goto(POST_URL);
+  await expect(page.locator('[data-testid="comment-form"]')).toBeVisible();
+
+  const deleteBtn = page.locator('[data-testid="delete-comment"]').first();
+  await expect(deleteBtn).toBeVisible();
+  await deleteBtn.click();
+
+  const confirmBtn = page.locator('[data-testid="confirm-delete"]').first();
+  await expect(confirmBtn).toBeVisible();
+
+  // The Cancel button has no data-testid — match on visible text (scoped
+  // to the group role to avoid ambiguity with any other "Cancel" control).
+  const cancel = page
+    .locator('[role="group"][aria-label="Confirm deletion"]')
+    .getByRole("button", { name: "Cancel" });
+  await expect(cancel).toBeVisible();
+  await cancel.click();
+
+  // Confirm row is gone, delete button reappears
+  await expect(confirmBtn).toHaveCount(0);
+  await expect(deleteBtn).toBeVisible();
+
+  // Focus is returned to the original delete button
+  const activeTestId = await page.evaluate(
+    () => document.activeElement?.getAttribute?.("data-testid") ?? null,
+  );
+  expect(activeTestId).toBe("delete-comment");
 });


### PR DESCRIPTION
## Summary

Phase 6 (Polish & Launch) for the comments feature — the final phase before the full MVP ships. Three commits across two waves plus a test-fix follow-up.

**Wave 1 (062b321):** privacy copy tightening on `CommentForm`, IP-hashing docstring clarifying that no IP data (raw or hashed) ever reaches Neon, full 30-item security audit passed with `READY TO SHIP` verdict (see `docs/comments-phase-6-audit-report.md`).

**Wave 2 (74bfc68):** 19 new Playwright tests (`CMT-E2E-13` → `-31`) covering token-page edge cases, admin login flow, honeypot behaviour, rate-limiting UX, a11y baseline (axe-core), error boundary, and focus management. Added a `test-unit` Vitest job to CI ahead of the Playwright job, upgraded workflow actions to v4, and enabled Playwright's `webServer` block so CI doesn't need a separate server process. New `lib/analytics.js` wrapper exposes `window.__lastTrackedEvent` for test hooks. `pages/owner/comments/delete.js` gets a `PLAYWRIGHT_TEST_COMMENT_PREVIEW` env-gated test seam so token-state rendering can be asserted without real Neon rows.

**Test fix (6515367):** resolved four Playwright failures surfaced by the new suite — `sr-only`/Playwright visibility heuristic (CMT-E2E-15), Next's `#__next-route-announcer__` tripping strict-mode on `[role=\"alert\"]` (CMT-E2E-23/-24/-25/-26), and a conditionally-rendered delete button being unreachable from a post-cancel `useEffect` (CMT-E2E-31). Fixed via DOM-walk visibility check, scoped selectors, and a ref-callback for focus restoration.

**Result:** 432/432 Playwright tests pass across chromium / firefox / webkit; 30/30 security checklist items pass; no data written to Neon beyond `post_id`, `author`, `body`.

## Test plan

- [x] Full Playwright suite passes locally (432 passed, 1.1m — chromium + firefox + webkit)
- [x] Vitest unit + integration suite passes
- [x] Security auditor run — 30/30 checks PASS
- [x] Local smoke test by owner — comments submit, render, rate-limit, honeypot swallowed silently, token-based delete link works
- [ ] CI green on both `test-unit` and `test` jobs
- [ ] Post-merge: 14-item production smoke checklist per `docs/comments-phase-6-qa-plan.md` §6

🤖 Generated with [Claude Code](https://claude.com/claude-code)