### PR TITLE
Fix TTFB and LCP performance issues

### DIFF
--- a/lib/posts.js
+++ b/lib/posts.js
@@ -3,7 +3,6 @@ import path from 'path';
 import matter from 'gray-matter';
 import { remark } from 'remark';
 import html from 'remark-html';
-import fsPromises from 'fs/promises';
 
 
 const postsDirectory = path.join(process.cwd(), 'posts');
@@ -153,26 +152,22 @@ export async function getPostDataByName(name) {
     };
 }
 
-export async function getPostsByTag(tag) {
+export function getPostsByTag(tag) {
+    // getSortedPostsData() already reads and parses every post's frontmatter
+    // (title, date, description, tags, readingTime) in a single pass. The tag
+    // listing page only renders that metadata — not the rendered HTML body —
+    // so re-reading each matched file from disk a second time was pure waste.
     const allPostsData = getSortedPostsData();
-    const postsWithTag = allPostsData.filter((post) => post.tags.includes(tag));
+    return allPostsData.filter((post) => post.tags.includes(tag));
+}
 
-    const results = await Promise.all(postsWithTag.map(async (post) => {
-        const fullPath = path.join(postsDirectory, `${post.id}.md`);
-        const fileContents = await fsPromises.readFile(fullPath, 'utf8');
-        const matterResult = matter(fileContents);
-
-        const processedContent = remark().use(html).processSync(matterResult.content);
-        const contentHtml = processedContent.toString();
-
-        return {
-            id: post.id,
-            contentHtml,
-            ...matterResult.data,
-        };
-    }));
-
-    return results;
+export function getAllTags() {
+    const allPostsData = getSortedPostsData();
+    const tagSet = new Set();
+    allPostsData.forEach((post) => {
+        post.tags.forEach((tag) => tagSet.add(tag));
+    });
+    return Array.from(tagSet);
 }
 
 export function getRelatedPosts(currentId, tags, limit = 3) {

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -38,7 +38,6 @@ export default function Contact() {
           >
             <div className="flex-0">
               <Image
-                priority
                 className="max-w-6! max-h-6! dark:invert"
                 src={email}
                 alt="Email Contact Icon"
@@ -60,7 +59,6 @@ export default function Contact() {
           >
             <div className="flex-0">
               <Image
-                priority
                 className="max-w-6! max-h-6! dark:invert"
                 src={linkedin}
                 alt="LinkedIn Contact Icon"
@@ -80,7 +78,6 @@ export default function Contact() {
           >
             <div className="flex-0">
               <Image
-                priority
                 className="max-w-6! max-h-6! dark:invert"
                 src={youtube}
                 alt="YouTube Contact Icon"
@@ -102,7 +99,6 @@ export default function Contact() {
           >
             <div className="flex-0">
               <Image
-                priority
                 className="max-w-6! max-h-6! dark:invert"
                 src={instagram}
                 alt="Instagram Contact Icon"
@@ -122,7 +118,6 @@ export default function Contact() {
           >
             <div className="flex-0">
               <Image
-                priority
                 className="max-w-6! max-h-6! dark:invert"
                 src={bluesky}
                 alt="Bluesky Contact Icon"
@@ -142,7 +137,6 @@ export default function Contact() {
           >
             <div className="flex-0">
               <Image
-                priority
                 className="max-w-6! max-h-6! dark:invert"
                 src={rss}
                 alt="RSS Feed Icon"

--- a/pages/posts/[id].js
+++ b/pages/posts/[id].js
@@ -83,6 +83,18 @@ export default function Post({ postData, relatedPosts }) {
                   </a>
                 );
               },
+              // Markdown images can't safely use next/image — arbitrary
+              // author-supplied images have no known dimensions at build
+              // time, and next/image requires either explicit width/height
+              // or `fill` inside a sized parent. Instead, defer loading and
+              // decoding for these (necessarily below-the-fold, non-LCP)
+              // images so they don't compete with the page's real LCP
+              // element for network/main-thread priority.
+              img: ({ node, alt, ...props }) => {
+                return (
+                  <img alt={alt || ""} loading="lazy" decoding="async" {...props} />
+                );
+              },
             }}
           >
             {postData.contentHtml}

--- a/pages/resume.js
+++ b/pages/resume.js
@@ -26,8 +26,6 @@ export default function Resume() {
               priority
               src={photo3}
               alt="Top Golf"
-              width={500}
-              height={500}
               className="w-full h-auto"
             />
           </div>
@@ -35,8 +33,6 @@ export default function Resume() {
             <Image
               src={photo2}
               alt="Natural History Museum"
-              width={500}
-              height={500}
               className="w-full h-auto"
             />
           </div>
@@ -44,8 +40,6 @@ export default function Resume() {
             <Image
               src={photo1}
               alt="Louvre"
-              width={500}
-              height={500}
               className="w-full h-auto"
             />
           </div>

--- a/pages/tags/[tag].js
+++ b/pages/tags/[tag].js
@@ -1,18 +1,28 @@
 import Layout from "../../components/layout";
-import { getPostsByTag } from "../../lib/posts"; // Import the function
+import { getPostsByTag, getAllTags } from "../../lib/posts"; // Import the function
 import Link from "next/link";
 import Head from "next/head";
 import Footer from "../../components/footer";
 
-export async function getServerSideProps({ params }) {
+export async function getStaticProps({ params }) {
   const tag = params.tag;
-  const posts = await getPostsByTag(tag);
+  const posts = getPostsByTag(tag);
 
   return {
     props: {
       tag,
       posts,
     },
+  };
+}
+
+export async function getStaticPaths() {
+  const tags = getAllTags();
+  const paths = tags.map((tag) => ({ params: { tag } }));
+
+  return {
+    paths,
+    fallback: false,
   };
 }
 


### PR DESCRIPTION
## Summary
Vercel Analytics flagged poor real-user FCP, LCP, and TTFB. This addresses the highest-impact findings from an investigation into those metrics:

- **TTFB**: `/tags/[tag]` used `getServerSideProps`, re-reading and re-parsing every post from disk on every request with no caching. Converted to `getStaticProps` + `getStaticPaths` so tag pages are prerendered at build time.
- **TTFB**: `getPostsByTag` in `lib/posts.js` was reading matched posts from disk a second time after already reading them via `getSortedPostsData()`. Now reuses the already-parsed metadata.
- **LCP**: `pages/resume.js` timeline photos had hardcoded `width={500} height={500}` on non-square static-import images, skewing the generated `srcset`. Removed in favor of intrinsic sizing.
- **LCP**: `pages/contact.js` marked all 6 small icon images `priority`, forcing 6 unnecessary preload `<link>` tags that competed with the actual LCP element. Removed.
- **LCP**: In-post markdown images (`pages/posts/[id].js`) rendered as plain `<img>` with no lazy loading. Added a custom renderer with `loading="lazy"` and `decoding="async"`.

## Test plan
- [x] `npm run build` — clean, `/tags/[tag]` confirmed SSG (●) in route output, 13 tag pages prerendered
- [x] `npm run playwright` — 423 passed, 9 skipped, 0 failed
- [x] Exploratory testing in browser: resume page (image aspect ratios correct, no distortion), contact page (0 image preload links, down from 6), tag page (`/tags/AI` renders correctly), blog post with embedded images (`loading="lazy"`/`decoding="async"` confirmed present, no console errors)
- [ ] Verify Core Web Vitals improvement on Vercel preview deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)